### PR TITLE
Fix calltips bug due to missing activeSignature

### DIFF
--- a/src/dcd/client.ts
+++ b/src/dcd/client.ts
@@ -126,7 +126,12 @@ export default class Client extends ev.EventEmitter {
                         let infoNumArg = infoArgs.match(/,/g);
 
                         signatureHelp.activeParameter = infoNumArg ? infoNumArg.length : 0;
-                        resolve(signatureHelp);
+                        signatureHelp.activeSignature = 0;
+                        if (this._operation == util.Operation.Calltips) {
+                            resolve(signatureHelp);
+                        } else {
+                            resolve([]);
+                        }
 
                         break;
                 }


### PR DESCRIPTION
Set the activeSignature as 0 as a workaround as there is no easy way to
figure out what is the activeSignature. Also, the SignatureHelp will
not be returned when a completion operation is requested.
