### PR TITLE
Fix number literals

### DIFF
--- a/syntaxes/d.tmLanguage
+++ b/syntaxes/d.tmLanguage
@@ -805,7 +805,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((0[bB][01_]+)|(0[xX][0-9a-fA-F_]*)|(([0-9_]+\.?[0-9_]*)|(\.[0-9_]+))((e|E)(\+|-)?[0-9_]+)?)([LlFfUuDd]|UL|ul)?\b</string>
+			<string>\b((0[bB][01_]*)|(0[xX][0-9a-fA-F_]*)|(((0|[1-9][0-9_]*)\.?[0-9_]*)|(\.[0-9_]+))((e|E)(\+|-)?[0-9_]+)?)([LlFfUuDd]|UL|ul)?\b</string>
 			<key>name</key>
 			<string>constant.numeric.d</string>
 		</dict>

--- a/syntaxes/d.tmLanguage
+++ b/syntaxes/d.tmLanguage
@@ -805,7 +805,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((0[bB][01]+)|(0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b</string>
+			<string>\b((0[bB][01_]+)|(0[xX][0-9a-fA-F_]*)|(([0-9_]+\.?[0-9_]*)|(\.[0-9_]+))((e|E)(\+|-)?[0-9_]+)?)([LlFfUuDd]|UL|ul)?\b</string>
 			<key>name</key>
 			<string>constant.numeric.d</string>
 		</dict>

--- a/syntaxes/d.tmLanguage
+++ b/syntaxes/d.tmLanguage
@@ -805,7 +805,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b</string>
+			<string>\b((0[bB][01]+)|(0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b</string>
 			<key>name</key>
 			<string>constant.numeric.d</string>
 		</dict>


### PR DESCRIPTION
There were issues with number literals:
- binary literals weren't highlighted
- underscores in numbers weren't highlighted

So I made some changes to the regex that matches them