### PR TITLE
Workaround for #21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+yarn.lock
 out
 .vscode/.browse.*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/src",
+			"outFiles": ["${workspaceRoot}/out/src"],
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test"],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/test",
+			"outFiles": ["${workspaceRoot}/out/test"],
 			"preLaunchTask": "npm"
 		}
 	]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,26 +5,24 @@
 // ${fileDirname}: the current opened file's dirname
 // ${fileExtname}: the current opened file's extension
 // ${cwd}: the current working directory of the spawned process
-
 // A task runner that calls a custom npm script that compiles the extension.
 {
 	"version": "0.1.0",
-
 	// we want to run npm
 	"command": "npm",
-
 	// the command is a shell script
 	"isShellCommand": true,
-
 	// show the output window only if unrecognized errors occur.
 	"showOutput": "silent",
-
 	// we run the custom script "compile" as defined in package.json
-	"args": ["run", "compile", "--loglevel", "silent"],
-
+	"args": [
+		"run",
+		"compile",
+		"--loglevel",
+		"silent"
+	],
 	// The tsc compiler is started in watching mode
-	"isWatching": true,
-
+	"isBackground": true,
 	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
 	"problemMatcher": "$tsc-watch"
 }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ After creating a debug configuration and the default dub tasks, simply change th
 * `d.tools.dfmt`: Path to the system DFMT executable (optional).
 * `d.tools.dscanner`: Path to the system Dscanner executable (optional).
 * `d.tools.dfix`: Path to the system Dfix executable (optional).
-* `d.dub.compiler`: The compiler used by dub when compiling other tools.
+* `d.dub.compiler`: The compiler used by dub when compiling other tools. Possible values:
+  * `dmd` [default]
+  * `ldc2`
+  * `gdc`
 * `d.tools.dProfileViewer`: Path to the system D Profile Viewer executable (optional).
 * `d.dcd.tcp`: Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows. Default value: `false`
 * `d.dcd.port`: Listens on this port instead of the default port 9166 when TCP sockets are used. Default value: `9166`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ After creating a debug configuration and the default dub tasks, simply change th
 
 ## Extension Settings
 
-* `d.dub`: Path to the `dub` executable. Default value: `dub`
 * `d.dmdConf.linux`: Path to the dmd configuration file on Linux. Default value: `/etc/dmd.conf`
 * `d.dmdConf.osx`: Path to the dmd configuration file on OS X. Default value: `/usr/local/etc/dmd.conf`
 * `d.dmdConf.windows`: Path to the dmd configuration file on Windows. Default value: `C:\\D\\dmd2\\windows\\bin\\sc.ini`
@@ -34,11 +33,13 @@ After creating a debug configuration and the default dub tasks, simply change th
 * `d.tools.enabled.dscanner`: Whether Dscanner is used or not. Default value: `true`
 * `d.tools.enabled.dfix`: Whether Dfix is used or not. Default value: `true`
 * `d.tools.enabled.dProfileViewer`: Whether D Profile Viewer is used or not. Default value: `true`
+* `d.tools.dub`: Path to the `dub` executable. Default value: `dub`
 * `d.tools.dcd.client`: Path to the system DCD client executable (optional).
 * `d.tools.dcd.server`: Path to the system DCD server executable (optional).
 * `d.tools.dfmt`: Path to the system DFMT executable (optional).
 * `d.tools.dscanner`: Path to the system Dscanner executable (optional).
 * `d.tools.dfix`: Path to the system Dfix executable (optional).
+* `d.dub.compiler`: The compiler used by dub when compiling other tools.
 * `d.tools.dProfileViewer`: Path to the system D Profile Viewer executable (optional).
 * `d.dcd.tcp`: Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows. Default value: `false`
 * `d.dcd.port`: Listens on this port instead of the default port 9166 when TCP sockets are used. Default value: `9166`

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ D Language Page: https://dlang.org/
 * Syntax Colorization
 * Snippets
 * Autocompletion and code navigation using [DCD](https://github.com/Hackerpilot/dcd)
-* Formatting using [dfmt](https://github.com/Hackerpilot/dfmt)
+* Formatting using [DFMT](https://github.com/Hackerpilot/dfmt)
 * Linting using [Dscanner](https://github.com/Hackerpilot/dscanner)
-* Code upgrade using [dfix](https://github.com/Hackerpilot/dfix)
+* Code upgrade using [Dfix](https://github.com/Hackerpilot/dfix)
 * Profiling using [D Profile Viewer](https://bitbucket.org/andrewtrotman/d-profile-viewer)
 * Integration with Dub using VSCode commands and tasks
 * [Dustmite](https://github.com/CyberShadow/DustMite/wiki) integration
@@ -44,8 +44,16 @@ After creating a debug configuration and the default dub tasks, simply change th
   * `ldc2`
   * `gdc`
 * `d.tools.dProfileViewer`: Path to the system D Profile Viewer executable (optional).
+* `d.dcd.compiler`: The compiler used by dub when compiling DCD. Possible values:
+  * `dmd`
+  * `ldc2`
+  * `gdc`
 * `d.dcd.tcp`: Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows. Default value: `false`
 * `d.dcd.port`: Listens on this port instead of the default port 9166 when TCP sockets are used. Default value: `9166`
+* `d.dfmt.compiler`: The compiler used by dub when compiling DFMT. Possible values:
+  * `dmd`
+  * `ldc2`
+  * `gdc`
 * `d.dfmt.alignSwitchStatements`: Align labels, cases, and defaults with their enclosing switch. Default value: `true`
 * `d.dfmt.braceStyle`: Denotes the style for using curly braces in code blocks. Possible values:
   * `allman` [default]
@@ -62,6 +70,18 @@ After creating a debug configuration and the default dub tasks, simply change th
 * `d.dfmt.selectiveImportSpace`: Insert space after the module name and before the ':' for selective imports. Default value: `true`
 * `d.dfmt.splitOperatorAtLineEnd`: Place operators on the end of the previous line when splitting lines. Default value: `false`
 * `d.dfmt.compactLabeledStatements`: Place labels on the same line as the labeled switch, for, foreach, or while statement. Default value: `true`
+* `d.dscanner.compiler`: The compiler used by dub when compiling Dscanner. Possible values:
+  * `dmd`
+  * `ldc2`
+  * `gdc`
+* `d.dfix.compiler`: The compiler used by dub when compiling Dfix. Possible values:
+  * `dmd`
+  * `ldc2`
+  * `gdc`
+* `d.dProfileViewer.compiler`: The compiler used by dub when compiling D Profile Viewer. Possible values:
+  * `dmd`
+  * `ldc2`
+  * `gdc`
 
 Note: these dfmt formatting options have yet to be implemented in dfmt itself and won't affect formatting for now:
 * `d.dfmt.alignSwitchStatements`
@@ -78,26 +98,33 @@ Note: these dfmt formatting options have yet to be implemented in dfmt itself an
 * `Upgrade Package Dependencies`: upgrade a package's dependencies
 * `Convert Dub File Format`: converts dub.json to SDL format or dub.sdl to JSON format
 * `Dustmite`: tries to build the project and sends the compiler output to Dustmite
+* `Install Tools`: shows tools that can be installed automatically
 
 ## Manual installation
 
-You have to install [the SDLang extension](https://marketplace.visualstudio.com/items?itemName=LaurentTreguier.sdlang) in order for dlang-vscode to work.
+You have to install [the SDLang extension](https://marketplace.visualstudio.com/items?itemName=LaurentTreguier.sdlang) in order to get dlang-vscode to work (it is an extension depency).
 
 ```sh
 git clone https://github.com/dlang-vscode/dlang-vscode
-git checkout dev # if you want to install the latest development version
+git checkout development # if you want to install the latest development version
 cd dlang-vscode
 npm install
 vsce package
 code dlang-<version>.vsix
 ```
 
+## Troubleshooting
+
+* Error when building tools at extension startup: some tools don't compile with the latest DMD versions. Solutions:
+  * Setting the `d.*.compiler` user options to `ldc2` or `gdc`
+  * Downgrading your version of DMD to 2.071.x
+* Currently, the latest stable versions of some tools used are quite old and may have some bugs that have only been fixed in the git HEAD version.
+
 ## TODO
 
 * Code coverage
 * GC profiling
-* Add range formatting
-* [Diet template](http://vibed.org/features#diet-templates) support
+* Range formatting
 * Code actions for fixing problems from linter
 * Symbol highlighting/renaming
 

--- a/package.json
+++ b/package.json
@@ -84,11 +84,6 @@
         "configuration": {
             "title": "D configuration",
             "properties": {
-                "d.dub": {
-                    "type": "string",
-                    "default": "dub",
-                    "description": "Path to the dub executable."
-                },
                 "d.dmdConf.linux": {
                     "type": "string",
                     "default": "/etc/dmd.conf",
@@ -129,6 +124,11 @@
                     "default": true,
                     "description": "Whether F Profile Viewer is used or not."
                 },
+                "d.tools.dub": {
+                    "type": "string",
+                    "default": "dub",
+                    "description": "Path to the dub executable."
+                },
                 "d.tools.dcd.client": {
                     "type": "string",
                     "default": "dcd-client",
@@ -158,6 +158,11 @@
                     "type": "string",
                     "default": "d-profile-viewer",
                     "description": "Path to the system D Profile Viewer executable (optional)."
+                },
+                "d.dub.compiler": {
+                    "type": "string",
+                    "default": "dmd",
+                    "description": "The compiler used by dub when compiling other tools."
                 },
                 "d.dcd.tcp": {
                     "type": "boolean",
@@ -317,7 +322,7 @@
     "devDependencies": {
         "typescript": "^2.1.4",
         "vscode": "^1.0.3",
-        "@types/node": "^6.0.52",
+        "@types/node": "^6.0.56",
         "@types/tmp": "^0.0.32",
         "@types/xml2js": "^0.0.32",
         "@types/escape-string-regexp": "^0.0.30"

--- a/package.json
+++ b/package.json
@@ -170,6 +170,16 @@
                         "gdc"
                     ]
                 },
+                "d.dcd.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling DCD.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                },
                 "d.dcd.tcp": {
                     "type": "boolean",
                     "default": false,
@@ -179,6 +189,16 @@
                     "type": "number",
                     "default": 9166,
                     "description": "Listens on this port instead of the default port 9166 when TCP sockets are used."
+                },
+                "d.dfmt.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling DFMT.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
                 },
                 "d.dfmt.alignSwitchStatements": {
                     "type": "boolean",
@@ -239,6 +259,36 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Place labels on the same line as the labeled switch, for, foreach, or while statement."
+                },
+                "d.dscanner.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling Dscanner.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                },
+                "d.dfix.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling Dfix.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                },
+                "d.dProfileViewer.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling D Profile Viewer.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -315,19 +315,20 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
+        "vscode:prepublish": "node ./node_modules/.bin/tsc -p ./",
+        "compile": "node ./node_modules/.bin/tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
-        "typescript": "^2.1.4",
+        "typescript": "^2.1.6",
         "vscode": "^1.0.3",
-        "@types/node": "^6.0.56",
+        "@types/node": "^7.0.5",
         "@types/tmp": "^0.0.32",
         "@types/xml2js": "^0.0.32",
         "@types/escape-string-regexp": "^0.0.30"
     },
     "dependencies": {
+        "meta-pkg": "^0.6.2",
         "tmp": "^0.0.31",
         "xml2js": "^0.4.17",
         "escape-string-regexp": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
         "onCommand:dlang.dub.convert",
         "onCommand:dlang.dub.dustmite",
         "onCommand:dlang.tasks.compiler",
-        "onCommand:dlang.tasks.build"
+        "onCommand:dlang.tasks.build",
+        "onCommand:dlang.install"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -301,6 +302,11 @@
                 "title": "Change Build Type",
                 "category": "Dlang",
                 "command": "dlang.tasks.build"
+            },
+            {
+                "title": "Install Tools",
+                "category": "Dlang",
+                "command": "dlang.install"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -389,7 +389,7 @@
         "@types/escape-string-regexp": "^0.0.30"
     },
     "dependencies": {
-        "meta-pkg": "^0.6.2",
+        "meta-pkg": "^0.6.4",
         "tmp": "^0.0.31",
         "xml2js": "^0.4.17",
         "escape-string-regexp": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -162,7 +162,12 @@
                 "d.dub.compiler": {
                     "type": "string",
                     "default": "dmd",
-                    "description": "The compiler used by dub when compiling other tools."
+                    "description": "The compiler used by dub when compiling other tools.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
                 },
                 "d.dcd.tcp": {
                     "type": "boolean",

--- a/packages/dmd.json
+++ b/packages/dmd.json
@@ -1,0 +1,12 @@
+{
+    "name": "dmd",
+    "targets": [
+        "dmd",
+        "rdmd"
+    ],
+    "backends": {
+        "packagekit": "dmd",
+        "brew": "dmd",
+        "chocolatey": "dmd"
+    }
+}

--- a/packages/dub.json
+++ b/packages/dub.json
@@ -1,0 +1,11 @@
+{
+    "name": "dub",
+    "targets": [
+        "dub"
+    ],
+    "backends": {
+        "packagekit": "dub",
+        "brew": "dub",
+        "chocolatey": "dub"
+    }
+}

--- a/packages/gdc.json
+++ b/packages/gdc.json
@@ -1,0 +1,9 @@
+{
+    "name": "gdc",
+    "targets": [
+        "gdc"
+    ],
+    "backends": {
+        "packagekit": "gdc"
+    }
+}

--- a/packages/ldc.json
+++ b/packages/ldc.json
@@ -1,0 +1,23 @@
+{
+    "name": "ldc",
+    "targets": [
+        "ldc2",
+        "ldmd2"
+    ],
+    "backends": {
+        "packagekit": "ldc",
+        "brew": "ldc",
+        "fallback": {
+            "name": "ldc",
+            "version": {
+                "feed": "https://github.com/ldc-developers/ldc/releases.atom",
+                "regexp": "LDC ([\\d.]+)$"
+            },
+            "win32": {
+                "source": "https://github.com/ldc-developers/ldc/releases/download/v%VERSION%/ldc2-%VERSION%-win64-msvc.zip",
+                "strip": 1,
+                "bin": "bin"
+            }
+        }
+    }
+}

--- a/packages/ldc.json
+++ b/packages/ldc.json
@@ -8,7 +8,6 @@
         "packagekit": "ldc",
         "brew": "ldc",
         "fallback": {
-            "name": "ldc",
             "version": {
                 "feed": "https://github.com/ldc-developers/ldc/releases.atom",
                 "regexp": "LDC ([\\d.]+)$"

--- a/src/dcd/server.ts
+++ b/src/dcd/server.ts
@@ -142,7 +142,7 @@ export default class Server {
 
                 allPackages.forEach((p) => {
                     if (p instanceof String) {
-                        let impAdded = this.getImportDirs(path.join(dubPath, p));
+                        let impAdded = this.getImportDirs(path.join(dubPath, <string>p));
                         impAdded.forEach((newP) => {
                             imp.add(newP);
                         });

--- a/src/dfmt.ts
+++ b/src/dfmt.ts
@@ -55,7 +55,7 @@ export default class Dfmt {
             output += data;
         });
 
-        this._dfmt.on('exit', () => {
+        this._dfmt.stdout.on('close', () => {
             let lastLine = this._document.lineCount - 1;
             let lastCol = this._document.lineAt(lastLine).text.length;
             let range = new vsc.Range(0, 0, lastLine, lastCol);

--- a/src/dub.ts
+++ b/src/dub.ts
@@ -13,10 +13,6 @@ export default class Dub extends vsc.Disposable {
     public static executable = vsc.workspace.getConfiguration().get('d.tools.dub', 'dub');
     private _tmp: tmp.SynchrounousResult;
 
-    public static check() {
-        return cp.spawnSync(Dub.executable, ['--help']).error;
-    }
-
     public constructor(private _output: vsc.OutputChannel) {
         super(null);
         this._tmp = tmp.dirSync();

--- a/src/dub.ts
+++ b/src/dub.ts
@@ -10,7 +10,7 @@ import * as tmp from 'tmp';
 import escapeStringRegexp = require('escape-string-regexp');
 
 export default class Dub extends vsc.Disposable {
-    public static executable = vsc.workspace.getConfiguration().get('d.dub', 'dub');
+    public static executable = vsc.workspace.getConfiguration().get('d.tools.dub', 'dub');
     private _tmp: tmp.SynchrounousResult;
 
     public static check() {
@@ -89,7 +89,7 @@ export default class Dub extends vsc.Disposable {
     }
 
     public build(p: Package, type: string, config?: string): Promise<Package> {
-        let args = ['--build=' + type];
+        let args = ['--build=' + type, '--compiler=' + vsc.workspace.getConfiguration().get('d.dub.compiler', 'dmd')];
 
         if (config) {
             args.push('--config=' + config);

--- a/src/dub.ts
+++ b/src/dub.ts
@@ -85,7 +85,8 @@ export default class Dub extends vsc.Disposable {
     }
 
     public build(p: Package, type: string, config?: string): Promise<Package> {
-        let compiler = vsc.workspace.getConfiguration().get<string>(`d.${p.name}.compiler`);
+        let packageName = p.name.replace(/-\w/g, (found) => found.substr(1, 1).toUpperCase());
+        let compiler = vsc.workspace.getConfiguration().get<string>(`d.${packageName}.compiler`);
         let args = ['--build=' + type, '--compiler=' +
             (compiler || vsc.workspace.getConfiguration().get('d.dub.compiler', 'dmd'))];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ class Tool {
     public activate: Function;
     private _name: string;
     private _configName: string;
-    private _buildConfig: string; i
+    private _buildConfig: string;
     private _isSystemTool = false;
     private _toolDirectory: string;
     private _toolFile: string;
@@ -191,9 +191,9 @@ export function activate(context: vsc.ExtensionContext) {
                             results.name + ' was upgraded'));
                 }
             })))
-        .then(Promise.all.bind(Promise)).then(() => {
-            start(context)
-        }).catch(console.log.bind(console));
+        .then(Promise.all.bind(Promise))
+        .then(start.bind(null, context))
+        .catch(console.log.bind(console));
 };
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,6 @@ class Tool {
     public build() {
         return Tool.dub.getLatestVersion(this._name)
             .then((p) => {
-                console.log(p.path);
                 this._toolDirectory = p.path;
                 return Tool.dub.build(p, 'release', this._buildConfig);
             });


### PR DESCRIPTION
This PR add two things :
- options in `package.json` to change the compiler used for compiling all the tools
- automatic install of compilers when possible

Using ldc instead of dmd can help mitigate #21 since the version of D it exposes is inferior to that of dmd. The compiler used by dub can be specified with `d.dub.compiler` for all tools, and can be overridden for specific tools (for example Dscanner just got an update and only seems to compiles with dmd now).

However, ldc needs to be installed for this workaround (obviously). So I tried to integrate a node module I started working on to automatically install compilers and dub if necessary. This makes it as easy to install ldc on Mac and most widespread Linux distributions, but also manages a local installation of ldc (with upgrade notifications) on Windows, which makes it less of a chore to use ldc.