### PR TITLE
Added framework for Testing Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode-test
+coverage
 node_modules
 yarn.lock
 out

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      export DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
       sleep 3;
     fi
@@ -30,7 +30,7 @@ before_script:
   - sudo apt-get update -qq
   - sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
   - sudo apt-get update -qq
-  - sudo apt-get install dmd-bin dub
+  - sudo apt-get -y install dmd-bin dub
 
 script:
   - npm test --silent

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ install:
 
 script:
   - npm test --silent
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
-sudo: false
+sudo: true
 
 language: node_js
 node_js:
   - "6"
 
 os:
-  - osx
   - linux
+
+before_script:
+  - sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
+  - sudo apt-get update -qq
+  - sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
+  - sudo apt-get update -qq
+  - sudo apt-get install dmd-bin dub unzip
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
@@ -14,6 +20,12 @@ before_install:
       sh -e /etc/init.d/xvfb start;
       sleep 3;
     fi
+  - pushd /tmp
+  - wget https://github.com/LaurentTreguier/sdlang-vscode/archive/master.zip -O sdlang.zip
+  - unzip sdlang.zip
+  - mkdir -p ~/.vscode/extensions
+  - mv sdlang-vscode-master ~/.vscode/extensions
+  - popd
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: true
+dist: trusty
+sudo: required
 
 language: node_js
 node_js:
@@ -6,13 +7,6 @@ node_js:
 
 os:
   - linux
-
-before_script:
-  - sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
-  - sudo apt-get update -qq
-  - sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
-  - sudo apt-get update -qq
-  - sudo apt-get install dmd-bin dub unzip
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
@@ -30,6 +24,13 @@ before_install:
 install:
   - npm install
   - npm run vscode:prepublish
+
+before_script:
+  - sudo wget http://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
+  - sudo apt-get update -qq
+  - sudo apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
+  - sudo apt-get update -qq
+  - sudo apt-get install dmd-bin dub
 
 script:
   - npm test --silent

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,8 @@
 			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceRoot}",
-				"--extensionTestsPath=${workspaceRoot}/out/test"
+				"--extensionTestsPath=${workspaceRoot}/out/test",
+				"${workspaceRoot}/test/d"
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,10 +18,10 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test"],
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/test"],
+			"outFiles": ["${workspaceRoot}/out/test/**/*.js"],
 			"preLaunchTask": "npm"
 		}
 	]

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,5 @@
 .vscode/**
+.vscode-test/**
 typings/**
 out/test/**
 test/**

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status (Linux)](https://img.shields.io/travis/dlang-vscode/dlang-vscode.svg?style=flat-square)](https://travis-ci.org/dlang-vscode/dlang-vscode)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/github/dlang-vscode/dlang-vscode?branch=master&svg=true)](https://ci.appveyor.com/project/mattiascibien/dlang-vscode)
 [![Dependency Status](https://www.versioneye.com/user/projects/58c669be01c96a0052f17bdf/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/58c669be01c96a0052f17bdf)
+[![codecov](https://codecov.io/gh/dlang-vscode/dlang-vscode/branch/master/graph/badge.svg)](https://codecov.io/gh/dlang-vscode/dlang-vscode)
 
 D Language Page: https://dlang.org/
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,11 @@ init:
 
 install:
   - ps: Install-Product node ''
+  - ps: Add-Type -assembly "system.io.compression.filesystem"
+  - ps: (new-object net.webclient).DownloadFile("https://github.com/LaurentTreguier/sdlang-vscode/archive/master.zip", "sdlang.zip")
+  - ps: '[io.compression.zipfile]::ExtractToDirectory(".\sdlang.zip", "$Env:HOME\.vscode\extensions")'
+  - cinst dmd
+  - cinst dub
   - npm install
   - npm install -g vsce
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ init:
   - git config --global core.autocrlf true
 
 install:
-  - mkdir %HOME%\.vscode\extensions
+  - mkdir %HOMEPATH%\.vscode\extensions
   - ps: Install-Product node ''
   - ps: Add-Type -assembly "system.io.compression.filesystem"
   - ps: (new-object net.webclient).DownloadFile("https://github.com/LaurentTreguier/sdlang-vscode/archive/master.zip", "sdlang.zip")
-  - ps: '[io.compression.zipfile]::ExtractToDirectory(".\sdlang.zip", "$Env:HOME\.vscode\extensions")'
+  - ps: '[io.compression.zipfile]::ExtractToDirectory(".\sdlang.zip", "$Env:HOMEPATH\.vscode\extensions")'
   - cinst -y dmd
   - cinst -y dub
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,13 @@ init:
   - git config --global core.autocrlf true
 
 install:
+  - mkdir %HOME%\.vscode\extensions
   - ps: Install-Product node ''
   - ps: Add-Type -assembly "system.io.compression.filesystem"
   - ps: (new-object net.webclient).DownloadFile("https://github.com/LaurentTreguier/sdlang-vscode/archive/master.zip", "sdlang.zip")
   - ps: '[io.compression.zipfile]::ExtractToDirectory(".\sdlang.zip", "$Env:HOME\.vscode\extensions")'
-  - cinst dmd
-  - cinst dub
+  - cinst -y dmd
+  - cinst -y dub
   - npm install
   - npm install -g vsce
 

--- a/coverconfig.json
+++ b/coverconfig.json
@@ -1,0 +1,9 @@
+{
+    "enabled": true,
+    "relativeSourcePath": "../src",
+    "relativeCoverageDir": "../../coverage",
+    "ignorePatterns": ["**/node_modules/**"],
+    "includePid": false,
+    "reports": ["json", "html", "lcov"],
+    "verbose": false
+}

--- a/package.json
+++ b/package.json
@@ -393,6 +393,7 @@
     "@types/node": "^7.0.5",
     "@types/tmp": "^0.0.32",
     "@types/xml2js": "^0.0.32",
+    "decache": "^4.1.0",
     "glob": "^7.1.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,422 +1,422 @@
 {
-    "name": "dlang",
-    "displayName": "D Language",
-    "description": "Support for the D Programming Language (https://dlang.org/)",
-    "version": "0.10.0",
-    "publisher": "dlang-vscode",
-    "license": "SEE LICENSE IN LICENSE.md",
-    "icon": "images/dlogo.png",
-    "homepage": "https://dlang-vscode.github.io/",
-    "galleryBanner": {
-        "color": "#B03931",
-        "theme": "dark"
-    },
-    "engines": {
-        "vscode": "^1.1.0"
-    },
-    "bugs": {
-        "url": "https://github.com/dlang-vscode/dlang-vscode/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/dlang-vscode/dlang-vscode.git"
-    },
-    "categories": [
-        "Languages",
-        "Snippets",
-        "Formatters",
-        "Linters",
-        "Other"
-    ],
-    "keywords": [
-        "dub",
-        "dcd",
-        "dfmt",
-        "dscanner",
-        "dfix"
-    ],
-    "activationEvents": [
-        "onLanguage:d",
-        "workspaceContains:dub.json",
-        "workspaceContains:dub.sdl",
-        "onCommand:dlang.defaultTasks",
-        "onCommand:dlang.install",
-        "onCommand:dlang.d-profile-viewer",
-        "onCommand:dlang.dcd.import",
-        "onCommand:dlang.dub.init",
-        "onCommand:dlang.dub.fetch",
-        "onCommand:dlang.dub.remove",
-        "onCommand:dlang.dub.upgrade",
-        "onCommand:dlang.dub.convert",
-        "onCommand:dlang.dub.dustmite",
-        "onCommand:dlang.tasks.compiler",
-        "onCommand:dlang.tasks.build",
-        "onCommand:dlang.action.dfix"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "languages": [
-            {
-                "id": "d",
-                "aliases": [
-                    "D",
-                    "d"
-                ],
-                "extensions": [
-                    ".d",
-                    ".di"
-                ],
-                "configuration": "./d.configuration.json"
-            }
+  "name": "dlang",
+  "displayName": "D Language",
+  "description": "Support for the D Programming Language (https://dlang.org/)",
+  "version": "0.10.0",
+  "publisher": "dlang-vscode",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "icon": "images/dlogo.png",
+  "homepage": "https://dlang-vscode.github.io/",
+  "galleryBanner": {
+    "color": "#B03931",
+    "theme": "dark"
+  },
+  "engines": {
+    "vscode": "^1.1.0"
+  },
+  "bugs": {
+    "url": "https://github.com/dlang-vscode/dlang-vscode/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dlang-vscode/dlang-vscode.git"
+  },
+  "categories": [
+    "Languages",
+    "Snippets",
+    "Formatters",
+    "Linters",
+    "Other"
+  ],
+  "keywords": [
+    "dub",
+    "dcd",
+    "dfmt",
+    "dscanner",
+    "dfix"
+  ],
+  "activationEvents": [
+    "onLanguage:d",
+    "workspaceContains:dub.json",
+    "workspaceContains:dub.sdl",
+    "onCommand:dlang.defaultTasks",
+    "onCommand:dlang.install",
+    "onCommand:dlang.d-profile-viewer",
+    "onCommand:dlang.dcd.import",
+    "onCommand:dlang.dub.init",
+    "onCommand:dlang.dub.fetch",
+    "onCommand:dlang.dub.remove",
+    "onCommand:dlang.dub.upgrade",
+    "onCommand:dlang.dub.convert",
+    "onCommand:dlang.dub.dustmite",
+    "onCommand:dlang.tasks.compiler",
+    "onCommand:dlang.tasks.build",
+    "onCommand:dlang.action.dfix"
+  ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "languages": [
+      {
+        "id": "d",
+        "aliases": [
+          "D",
+          "d"
         ],
-        "grammars": [
-            {
-                "language": "d",
-                "scopeName": "source.d",
-                "path": "./syntaxes/d.tmLanguage"
-            }
+        "extensions": [
+          ".d",
+          ".di"
         ],
-        "snippets": [
-            {
-                "language": "d",
-                "path": "./snippets/snippets.json"
-            }
-        ],
-        "configuration": {
-            "title": "D configuration",
-            "properties": {
-                "d.dmdConf.linux": {
-                    "type": "string",
-                    "default": "/etc/dmd.conf",
-                    "description": "Path to the DMD configuration file on Linux."
-                },
-                "d.dmdConf.osx": {
-                    "type": "string",
-                    "default": "/usr/local/etc/dmd.conf",
-                    "description": "Path to the DMD configuration file on OS X."
-                },
-                "d.dmdConf.windows": {
-                    "type": "string",
-                    "default": "C:\\D\\dmd2\\windows\\bin\\sc.ini",
-                    "description": "Path to the DMD configuration file on Windows."
-                },
-                "d.tools.enabled.dcd": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether DCD is used or not."
-                },
-                "d.tools.enabled.dfmt": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether DFMT is used or not."
-                },
-                "d.tools.enabled.dscanner": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether Dscanner is used or not."
-                },
-                "d.tools.enabled.dfix": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether Dfix is used or not."
-                },
-                "d.tools.enabled.dProfileViewer": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether F Profile Viewer is used or not."
-                },
-                "d.tools.dub": {
-                    "type": "string",
-                    "default": "dub",
-                    "description": "Path to the dub executable."
-                },
-                "d.tools.dcd.client": {
-                    "type": "string",
-                    "default": "dcd-client",
-                    "description": "Path to the system DCD client executable (optional)."
-                },
-                "d.tools.dcd.server": {
-                    "type": "string",
-                    "default": "dcd-server",
-                    "description": "Path to the system DCD server executable (optional)."
-                },
-                "d.tools.dfmt": {
-                    "type": "string",
-                    "default": "dfmt",
-                    "description": "Path to the system DFMT executable (optional)."
-                },
-                "d.tools.dscanner": {
-                    "type": "string",
-                    "default": "dscanner",
-                    "description": "Path to the system Dscanner executable (optional)."
-                },
-                "d.tools.dfix": {
-                    "type": "string",
-                    "default": "dfix",
-                    "description": "Path to the system Dfix executable (optional)."
-                },
-                "d.tools.dProfileViewer": {
-                    "type": "string",
-                    "default": "d-profile-viewer",
-                    "description": "Path to the system D Profile Viewer executable (optional)."
-                },
-                "d.dub.compiler": {
-                    "type": "string",
-                    "default": "dmd",
-                    "description": "The compiler used by dub when compiling other tools.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dcd.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling DCD.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dcd.tcp": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows."
-                },
-                "d.dcd.port": {
-                    "type": "number",
-                    "default": 9166,
-                    "description": "Listens on this port instead of the default port 9166 when TCP sockets are used."
-                },
-                "d.dcd.imports": {
-                    "type": "array",
-                    "default": [],
-                    "description": "An array of paths that DCD should import on launch."
-                },
-                "d.dfmt.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling DFMT.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dfmt.alignSwitchStatements": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Align labels, cases, and defaults with their enclosing switch."
-                },
-                "d.dfmt.braceStyle": {
-                    "type": "string",
-                    "default": "allman",
-                    "description": "Denotes the style for using curly braces in code blocks.",
-                    "enum": [
-                        "allman",
-                        "otbs",
-                        "stroustrup"
-                    ]
-                },
-                "d.dfmt.endOfLine": {
-                    "type": "string",
-                    "default": "lf",
-                    "description": "Line ending file format.",
-                    "enum": [
-                        "lf",
-                        "cr",
-                        "crlf"
-                    ]
-                },
-                "d.dfmt.softMaxLineLength": {
-                    "type": "number",
-                    "default": 80,
-                    "description": "The formatting process will usually keep lines below this length."
-                },
-                "d.dfmt.maxLineLength": {
-                    "type": "number",
-                    "default": 120,
-                    "description": "Forces hard line wrapping after the amount of characters specified."
-                },
-                "d.dfmt.outdentAttributes": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Decrease the indentation level of attributes."
-                },
-                "d.dfmt.spaceAfterCast": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Insert space after the closing parenthesis of a cast expression."
-                },
-                "d.dfmt.selectiveImportSpace": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Insert space after the module name and before the ':' for selective imports."
-                },
-                "d.dfmt.splitOperatorAtLineEnd": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Place operators on the end of the previous line when splitting lines."
-                },
-                "d.dfmt.compactLabeledStatements": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Place labels on the same line as the labeled switch, for, foreach, or while statement."
-                },
-                "d.dscanner.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling Dscanner.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dfix.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling Dfix.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dProfileViewer.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling D Profile Viewer.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                }
-            }
+        "configuration": "./d.configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "d",
+        "scopeName": "source.d",
+        "path": "./syntaxes/d.tmLanguage"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "d",
+        "path": "./snippets/snippets.json"
+      }
+    ],
+    "configuration": {
+      "title": "D configuration",
+      "properties": {
+        "d.dmdConf.linux": {
+          "type": "string",
+          "default": "/etc/dmd.conf",
+          "description": "Path to the DMD configuration file on Linux."
         },
-        "commands": [
-            {
-                "title": "Create Default Tasks",
-                "category": "Dlang",
-                "command": "dlang.defaultTasks"
-            },
-            {
-                "title": "Install Tools",
-                "category": "Dlang",
-                "command": "dlang.install"
-            },
-            {
-                "title": "See Program Profile",
-                "category": "Dlang",
-                "command": "dlang.d-profile-viewer"
-            },
-            {
-                "title": "Add Import Path To DCD",
-                "category": "DCD",
-                "command": "dlang.dcd.import"
-            },
-            {
-                "title": "Init Package",
-                "category": "Dub",
-                "command": "dlang.dub.init"
-            },
-            {
-                "title": "Fetch Package",
-                "category": "Dub",
-                "command": "dlang.dub.fetch"
-            },
-            {
-                "title": "Remove Package",
-                "category": "Dub",
-                "command": "dlang.dub.remove"
-            },
-            {
-                "title": "Upgrade Package Dependencies",
-                "category": "Dub",
-                "command": "dlang.dub.upgrade"
-            },
-            {
-                "title": "Convert Dub File Format",
-                "category": "Dub",
-                "command": "dlang.dub.convert"
-            },
-            {
-                "title": "Dustmite",
-                "category": "Dub",
-                "command": "dlang.dub.dustmite"
-            },
-            {
-                "title": "Change Compiler",
-                "category": "Dlang",
-                "command": "dlang.tasks.compiler"
-            },
-            {
-                "title": "Change Build Type",
-                "category": "Dlang",
-                "command": "dlang.tasks.build"
-            },
-            {
-                "title": "Disable Check",
-                "category": "Dlang Actions",
-                "command": "dlang.actions.config"
-            },
-            {
-                "title": "Run Dfix",
-                "category": "Dlang Actions",
-                "command": "dlang.actions.dfix"
-            },
-            {
-                "title": "Replace `delete` With `destroy()`",
-                "category": "Dlang Actions",
-                "command": "dlang.actions.replaceDeletes"
-            },
-            {
-                "title": "Sort Imports",
-                "category": "Dlang Actions",
-                "command": "dlang.actions.sortImports"
-            }
-        ],
-        "menus": {
-            "editor/title": [
-                {
-                    "group": "dlang",
-                    "command": "dlang.actions.dfix",
-                    "when": "resourceLangId == d"
-                }
-            ],
-            "explorer/context": [
-                {
-                    "group": "dlang",
-                    "command": "dlang.dcd.import"
-                }
-            ]
+        "d.dmdConf.osx": {
+          "type": "string",
+          "default": "/usr/local/etc/dmd.conf",
+          "description": "Path to the DMD configuration file on OS X."
+        },
+        "d.dmdConf.windows": {
+          "type": "string",
+          "default": "C:\\D\\dmd2\\windows\\bin\\sc.ini",
+          "description": "Path to the DMD configuration file on Windows."
+        },
+        "d.tools.enabled.dcd": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether DCD is used or not."
+        },
+        "d.tools.enabled.dfmt": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether DFMT is used or not."
+        },
+        "d.tools.enabled.dscanner": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether Dscanner is used or not."
+        },
+        "d.tools.enabled.dfix": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether Dfix is used or not."
+        },
+        "d.tools.enabled.dProfileViewer": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether F Profile Viewer is used or not."
+        },
+        "d.tools.dub": {
+          "type": "string",
+          "default": "dub",
+          "description": "Path to the dub executable."
+        },
+        "d.tools.dcd.client": {
+          "type": "string",
+          "default": "dcd-client",
+          "description": "Path to the system DCD client executable (optional)."
+        },
+        "d.tools.dcd.server": {
+          "type": "string",
+          "default": "dcd-server",
+          "description": "Path to the system DCD server executable (optional)."
+        },
+        "d.tools.dfmt": {
+          "type": "string",
+          "default": "dfmt",
+          "description": "Path to the system DFMT executable (optional)."
+        },
+        "d.tools.dscanner": {
+          "type": "string",
+          "default": "dscanner",
+          "description": "Path to the system Dscanner executable (optional)."
+        },
+        "d.tools.dfix": {
+          "type": "string",
+          "default": "dfix",
+          "description": "Path to the system Dfix executable (optional)."
+        },
+        "d.tools.dProfileViewer": {
+          "type": "string",
+          "default": "d-profile-viewer",
+          "description": "Path to the system D Profile Viewer executable (optional)."
+        },
+        "d.dub.compiler": {
+          "type": "string",
+          "default": "dmd",
+          "description": "The compiler used by dub when compiling other tools.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dcd.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling DCD.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dcd.tcp": {
+          "type": "boolean",
+          "default": false,
+          "description": "Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows."
+        },
+        "d.dcd.port": {
+          "type": "number",
+          "default": 9166,
+          "description": "Listens on this port instead of the default port 9166 when TCP sockets are used."
+        },
+        "d.dcd.imports": {
+          "type": "array",
+          "default": [],
+          "description": "An array of paths that DCD should import on launch."
+        },
+        "d.dfmt.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling DFMT.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dfmt.alignSwitchStatements": {
+          "type": "boolean",
+          "default": true,
+          "description": "Align labels, cases, and defaults with their enclosing switch."
+        },
+        "d.dfmt.braceStyle": {
+          "type": "string",
+          "default": "allman",
+          "description": "Denotes the style for using curly braces in code blocks.",
+          "enum": [
+            "allman",
+            "otbs",
+            "stroustrup"
+          ]
+        },
+        "d.dfmt.endOfLine": {
+          "type": "string",
+          "default": "lf",
+          "description": "Line ending file format.",
+          "enum": [
+            "lf",
+            "cr",
+            "crlf"
+          ]
+        },
+        "d.dfmt.softMaxLineLength": {
+          "type": "number",
+          "default": 80,
+          "description": "The formatting process will usually keep lines below this length."
+        },
+        "d.dfmt.maxLineLength": {
+          "type": "number",
+          "default": 120,
+          "description": "Forces hard line wrapping after the amount of characters specified."
+        },
+        "d.dfmt.outdentAttributes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Decrease the indentation level of attributes."
+        },
+        "d.dfmt.spaceAfterCast": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert space after the closing parenthesis of a cast expression."
+        },
+        "d.dfmt.selectiveImportSpace": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert space after the module name and before the ':' for selective imports."
+        },
+        "d.dfmt.splitOperatorAtLineEnd": {
+          "type": "boolean",
+          "default": false,
+          "description": "Place operators on the end of the previous line when splitting lines."
+        },
+        "d.dfmt.compactLabeledStatements": {
+          "type": "boolean",
+          "default": true,
+          "description": "Place labels on the same line as the labeled switch, for, foreach, or while statement."
+        },
+        "d.dscanner.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling Dscanner.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dfix.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling Dfix.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dProfileViewer.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling D Profile Viewer.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
         }
+      }
     },
-    "scripts": {
-        "vscode:prepublish": "./node_modules/.bin/tsc -p ./",
-        "compile": "./node_modules/.bin/tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "devDependencies": {
-        "@types/escape-string-regexp": "^0.0.30",
-        "@types/fs-extra": "^0.0.37",
-        "@types/node": "^7.0.8",
-        "@types/tmp": "^0.0.32",
-        "@types/xml2js": "^0.0.33",
-        "typescript": "^2.2.1",
-        "vscode": "^1.1.0"
-    },
-    "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "fs-extra": "^2.0.0",
-        "meta-pkg": "^0.6.4",
-        "tmp": "^0.0.31",
-        "xml2js": "^0.4.17"
-    },
-    "extensionDependencies": [
-        "LaurentTreguier.sdlang"
-    ]
+    "commands": [
+      {
+        "title": "Create Default Tasks",
+        "category": "Dlang",
+        "command": "dlang.defaultTasks"
+      },
+      {
+        "title": "Install Tools",
+        "category": "Dlang",
+        "command": "dlang.install"
+      },
+      {
+        "title": "See Program Profile",
+        "category": "Dlang",
+        "command": "dlang.d-profile-viewer"
+      },
+      {
+        "title": "Add Import Path To DCD",
+        "category": "DCD",
+        "command": "dlang.dcd.import"
+      },
+      {
+        "title": "Init Package",
+        "category": "Dub",
+        "command": "dlang.dub.init"
+      },
+      {
+        "title": "Fetch Package",
+        "category": "Dub",
+        "command": "dlang.dub.fetch"
+      },
+      {
+        "title": "Remove Package",
+        "category": "Dub",
+        "command": "dlang.dub.remove"
+      },
+      {
+        "title": "Upgrade Package Dependencies",
+        "category": "Dub",
+        "command": "dlang.dub.upgrade"
+      },
+      {
+        "title": "Convert Dub File Format",
+        "category": "Dub",
+        "command": "dlang.dub.convert"
+      },
+      {
+        "title": "Dustmite",
+        "category": "Dub",
+        "command": "dlang.dub.dustmite"
+      },
+      {
+        "title": "Change Compiler",
+        "category": "Dlang",
+        "command": "dlang.tasks.compiler"
+      },
+      {
+        "title": "Change Build Type",
+        "category": "Dlang",
+        "command": "dlang.tasks.build"
+      },
+      {
+        "title": "Disable Check",
+        "category": "Dlang Actions",
+        "command": "dlang.actions.config"
+      },
+      {
+        "title": "Run Dfix",
+        "category": "Dlang Actions",
+        "command": "dlang.actions.dfix"
+      },
+      {
+        "title": "Replace `delete` With `destroy()`",
+        "category": "Dlang Actions",
+        "command": "dlang.actions.replaceDeletes"
+      },
+      {
+        "title": "Sort Imports",
+        "category": "Dlang Actions",
+        "command": "dlang.actions.sortImports"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "group": "dlang",
+          "command": "dlang.actions.dfix",
+          "when": "resourceLangId == d"
+        }
+      ],
+      "explorer/context": [
+        {
+          "group": "dlang",
+          "command": "dlang.dcd.import"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "./node_modules/.bin/tsc -p ./",
+    "compile": "./node_modules/.bin/tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "devDependencies": {
+    "@types/escape-string-regexp": "^0.0.30",
+    "@types/fs-extra": "^2.0.0",
+    "@types/node": "^7.0.10",
+    "@types/tmp": "^0.0.32",
+    "@types/xml2js": "^0.0.33",
+    "typescript": "^2.2.1",
+    "vscode": "^1.1.0"
+  },
+  "dependencies": {
+    "escape-string-regexp": "^1.0.5",
+    "fs-extra": "^2.1.2",
+    "meta-pkg": "^0.6.4",
+    "tmp": "^0.0.31",
+    "xml2js": "^0.4.17"
+  },
+  "extensionDependencies": [
+    "LaurentTreguier.sdlang"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,405 +1,412 @@
 {
-    "name": "dlang",
-    "displayName": "D Language",
-    "description": "Support for the D Programming Language (https://dlang.org/)",
-    "version": "0.9.0",
-    "publisher": "dlang-vscode",
-    "license": "SEE LICENSE IN LICENSE.md",
-    "icon": "images/dlogo.png",
-    "homepage": "https://dlang-vscode.github.io/",
-    "galleryBanner": {
-        "color": "#B03931",
-        "theme": "dark"
-    },
-    "engines": {
-        "vscode": "^1.0.0"
-    },
-    "bugs": {
-        "url": "https://github.com/dlang-vscode/dlang-vscode/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/dlang-vscode/dlang-vscode.git"
-    },
-    "categories": [
-        "Languages",
-        "Snippets",
-        "Formatters",
-        "Linters",
-        "Other"
-    ],
-    "keywords": [
-        "dub",
-        "dcd",
-        "dfmt",
-        "dscanner",
-        "dfix"
-    ],
-    "activationEvents": [
-        "onLanguage:d",
-        "workspaceContains:dub.json",
-        "workspaceContains:dub.sdl",
-        "onCommand:dlang.default-tasks",
-        "onCommand:dlang.dfix",
-        "onCommand:dlang.d-profile-viewer",
-        "onCommand:dlang.dcd.import",
-        "onCommand:dlang.dub.init",
-        "onCommand:dlang.dub.fetch",
-        "onCommand:dlang.dub.remove",
-        "onCommand:dlang.dub.upgrade",
-        "onCommand:dlang.dub.convert",
-        "onCommand:dlang.dub.dustmite",
-        "onCommand:dlang.tasks.compiler",
-        "onCommand:dlang.tasks.build",
-        "onCommand:dlang.install"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "languages": [
-            {
-                "id": "d",
-                "aliases": [
-                    "D",
-                    "d"
-                ],
-                "extensions": [
-                    ".d",
-                    ".di"
-                ],
-                "configuration": "./d.configuration.json"
-            }
+  "name": "dlang",
+  "displayName": "D Language",
+  "description": "Support for the D Programming Language (https://dlang.org/)",
+  "version": "0.9.0",
+  "publisher": "dlang-vscode",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "icon": "images/dlogo.png",
+  "homepage": "https://dlang-vscode.github.io/",
+  "galleryBanner": {
+    "color": "#B03931",
+    "theme": "dark"
+  },
+  "engines": {
+    "vscode": "^1.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/dlang-vscode/dlang-vscode/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dlang-vscode/dlang-vscode.git"
+  },
+  "categories": [
+    "Languages",
+    "Snippets",
+    "Formatters",
+    "Linters",
+    "Other"
+  ],
+  "keywords": [
+    "dub",
+    "dcd",
+    "dfmt",
+    "dscanner",
+    "dfix"
+  ],
+  "activationEvents": [
+    "onLanguage:d",
+    "workspaceContains:dub.json",
+    "workspaceContains:dub.sdl",
+    "onCommand:dlang.default-tasks",
+    "onCommand:dlang.dfix",
+    "onCommand:dlang.d-profile-viewer",
+    "onCommand:dlang.dcd.import",
+    "onCommand:dlang.dub.init",
+    "onCommand:dlang.dub.fetch",
+    "onCommand:dlang.dub.remove",
+    "onCommand:dlang.dub.upgrade",
+    "onCommand:dlang.dub.convert",
+    "onCommand:dlang.dub.dustmite",
+    "onCommand:dlang.tasks.compiler",
+    "onCommand:dlang.tasks.build",
+    "onCommand:dlang.install"
+  ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "languages": [
+      {
+        "id": "d",
+        "aliases": [
+          "D",
+          "d"
         ],
-        "grammars": [
-            {
-                "language": "d",
-                "scopeName": "source.d",
-                "path": "./syntaxes/d.tmLanguage"
-            }
+        "extensions": [
+          ".d",
+          ".di"
         ],
-        "snippets": [
-            {
-                "language": "d",
-                "path": "./snippets/snippets.json"
-            }
-        ],
-        "configuration": {
-            "title": "D configuration",
-            "properties": {
-                "d.dmdConf.linux": {
-                    "type": "string",
-                    "default": "/etc/dmd.conf",
-                    "description": "Path to the DMD configuration file on Linux."
-                },
-                "d.dmdConf.osx": {
-                    "type": "string",
-                    "default": "/usr/local/etc/dmd.conf",
-                    "description": "Path to the DMD configuration file on OS X."
-                },
-                "d.dmdConf.windows": {
-                    "type": "string",
-                    "default": "C:\\D\\dmd2\\windows\\bin\\sc.ini",
-                    "description": "Path to the DMD configuration file on Windows."
-                },
-                "d.tools.enabled.dcd": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether DCD is used or not."
-                },
-                "d.tools.enabled.dfmt": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether DFMT is used or not."
-                },
-                "d.tools.enabled.dscanner": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether Dscanner is used or not."
-                },
-                "d.tools.enabled.dfix": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether Dfix is used or not."
-                },
-                "d.tools.enabled.dProfileViewer": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether F Profile Viewer is used or not."
-                },
-                "d.tools.dub": {
-                    "type": "string",
-                    "default": "dub",
-                    "description": "Path to the dub executable."
-                },
-                "d.tools.dcd.client": {
-                    "type": "string",
-                    "default": "dcd-client",
-                    "description": "Path to the system DCD client executable (optional)."
-                },
-                "d.tools.dcd.server": {
-                    "type": "string",
-                    "default": "dcd-server",
-                    "description": "Path to the system DCD server executable (optional)."
-                },
-                "d.tools.dfmt": {
-                    "type": "string",
-                    "default": "dfmt",
-                    "description": "Path to the system DFMT executable (optional)."
-                },
-                "d.tools.dscanner": {
-                    "type": "string",
-                    "default": "dscanner",
-                    "description": "Path to the system Dscanner executable (optional)."
-                },
-                "d.tools.dfix": {
-                    "type": "string",
-                    "default": "dfix",
-                    "description": "Path to the system Dfix executable (optional)."
-                },
-                "d.tools.dProfileViewer": {
-                    "type": "string",
-                    "default": "d-profile-viewer",
-                    "description": "Path to the system D Profile Viewer executable (optional)."
-                },
-                "d.dub.compiler": {
-                    "type": "string",
-                    "default": "dmd",
-                    "description": "The compiler used by dub when compiling other tools.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dcd.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling DCD.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dcd.tcp": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows."
-                },
-                "d.dcd.port": {
-                    "type": "number",
-                    "default": 9166,
-                    "description": "Listens on this port instead of the default port 9166 when TCP sockets are used."
-                },
-                "d.dcd.imports": {
-                    "type": "array",
-                    "default": [],
-                    "description": "An array of paths that DCD should import on launch."
-                },
-                "d.dfmt.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling DFMT.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dfmt.alignSwitchStatements": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Align labels, cases, and defaults with their enclosing switch."
-                },
-                "d.dfmt.braceStyle": {
-                    "type": "string",
-                    "default": "allman",
-                    "description": "Denotes the style for using curly braces in code blocks.",
-                    "enum": [
-                        "allman",
-                        "otbs",
-                        "stroustrup"
-                    ]
-                },
-                "d.dfmt.endOfLine": {
-                    "type": "string",
-                    "default": "lf",
-                    "description": "Line ending file format.",
-                    "enum": [
-                        "lf",
-                        "cr",
-                        "crlf"
-                    ]
-                },
-                "d.dfmt.softMaxLineLength": {
-                    "type": "number",
-                    "default": 80,
-                    "description": "The formatting process will usually keep lines below this length."
-                },
-                "d.dfmt.maxLineLength": {
-                    "type": "number",
-                    "default": 120,
-                    "description": "Forces hard line wrapping after the amount of characters specified."
-                },
-                "d.dfmt.outdentAttributes": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Decrease the indentation level of attributes."
-                },
-                "d.dfmt.spaceAfterCast": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Insert space after the closing parenthesis of a cast expression."
-                },
-                "d.dfmt.selectiveImportSpace": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Insert space after the module name and before the ':' for selective imports."
-                },
-                "d.dfmt.splitOperatorAtLineEnd": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Place operators on the end of the previous line when splitting lines."
-                },
-                "d.dfmt.compactLabeledStatements": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Place labels on the same line as the labeled switch, for, foreach, or while statement."
-                },
-                "d.dscanner.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling Dscanner.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dfix.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling Dfix.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                },
-                "d.dProfileViewer.compiler": {
-                    "type": "string",
-                    "default": null,
-                    "description": "The compiler used by dub when compiling D Profile Viewer.",
-                    "enum": [
-                        "dmd",
-                        "ldc2",
-                        "gdc"
-                    ]
-                }
-            }
+        "configuration": "./d.configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "d",
+        "scopeName": "source.d",
+        "path": "./syntaxes/d.tmLanguage"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "d",
+        "path": "./snippets/snippets.json"
+      }
+    ],
+    "configuration": {
+      "title": "D configuration",
+      "properties": {
+        "d.dmdConf.linux": {
+          "type": "string",
+          "default": "/etc/dmd.conf",
+          "description": "Path to the DMD configuration file on Linux."
         },
-        "commands": [
-            {
-                "title": "Create Default Tasks",
-                "category": "Dlang",
-                "command": "dlang.default-tasks"
-            },
-            {
-                "title": "Run Dfix",
-                "category": "Dlang",
-                "command": "dlang.dfix"
-            },
-            {
-                "title": "See Program Profile",
-                "category": "Dlang",
-                "command": "dlang.d-profile-viewer"
-            },
-            {
-                "title": "Add Import Path To DCD",
-                "category": "DCD",
-                "command": "dlang.dcd.import"
-            },
-            {
-                "title": "Init Package",
-                "category": "Dub",
-                "command": "dlang.dub.init"
-            },
-            {
-                "title": "Fetch Package",
-                "category": "Dub",
-                "command": "dlang.dub.fetch"
-            },
-            {
-                "title": "Remove Package",
-                "category": "Dub",
-                "command": "dlang.dub.remove"
-            },
-            {
-                "title": "Upgrade Package Dependencies",
-                "category": "Dub",
-                "command": "dlang.dub.upgrade"
-            },
-            {
-                "title": "Convert Dub File Format",
-                "category": "Dub",
-                "command": "dlang.dub.convert"
-            },
-            {
-                "title": "Dustmite",
-                "category": "Dub",
-                "command": "dlang.dub.dustmite"
-            },
-            {
-                "title": "Change Compiler",
-                "category": "Dlang",
-                "command": "dlang.tasks.compiler"
-            },
-            {
-                "title": "Change Build Type",
-                "category": "Dlang",
-                "command": "dlang.tasks.build"
-            },
-            {
-                "title": "Install Tools",
-                "category": "Dlang",
-                "command": "dlang.install"
-            }
-        ],
-        "menus": {
-            "editor/title": [
-                {
-                    "group": "dlang",
-                    "command": "dlang.dfix",
-                    "when": "resourceLangId == d"
-                }
-            ],
-            "explorer/context": [
-                {
-                    "group": "dlang",
-                    "command": "dlang.dcd.import"
-                }
-            ]
+        "d.dmdConf.osx": {
+          "type": "string",
+          "default": "/usr/local/etc/dmd.conf",
+          "description": "Path to the DMD configuration file on OS X."
+        },
+        "d.dmdConf.windows": {
+          "type": "string",
+          "default": "C:\\D\\dmd2\\windows\\bin\\sc.ini",
+          "description": "Path to the DMD configuration file on Windows."
+        },
+        "d.tools.enabled.dcd": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether DCD is used or not."
+        },
+        "d.tools.enabled.dfmt": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether DFMT is used or not."
+        },
+        "d.tools.enabled.dscanner": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether Dscanner is used or not."
+        },
+        "d.tools.enabled.dfix": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether Dfix is used or not."
+        },
+        "d.tools.enabled.dProfileViewer": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether F Profile Viewer is used or not."
+        },
+        "d.tools.dub": {
+          "type": "string",
+          "default": "dub",
+          "description": "Path to the dub executable."
+        },
+        "d.tools.dcd.client": {
+          "type": "string",
+          "default": "dcd-client",
+          "description": "Path to the system DCD client executable (optional)."
+        },
+        "d.tools.dcd.server": {
+          "type": "string",
+          "default": "dcd-server",
+          "description": "Path to the system DCD server executable (optional)."
+        },
+        "d.tools.dfmt": {
+          "type": "string",
+          "default": "dfmt",
+          "description": "Path to the system DFMT executable (optional)."
+        },
+        "d.tools.dscanner": {
+          "type": "string",
+          "default": "dscanner",
+          "description": "Path to the system Dscanner executable (optional)."
+        },
+        "d.tools.dfix": {
+          "type": "string",
+          "default": "dfix",
+          "description": "Path to the system Dfix executable (optional)."
+        },
+        "d.tools.dProfileViewer": {
+          "type": "string",
+          "default": "d-profile-viewer",
+          "description": "Path to the system D Profile Viewer executable (optional)."
+        },
+        "d.dub.compiler": {
+          "type": "string",
+          "default": "dmd",
+          "description": "The compiler used by dub when compiling other tools.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dcd.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling DCD.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dcd.tcp": {
+          "type": "boolean",
+          "default": false,
+          "description": "Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows."
+        },
+        "d.dcd.port": {
+          "type": "number",
+          "default": 9166,
+          "description": "Listens on this port instead of the default port 9166 when TCP sockets are used."
+        },
+        "d.dcd.imports": {
+          "type": "array",
+          "default": [],
+          "description": "An array of paths that DCD should import on launch."
+        },
+        "d.dfmt.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling DFMT.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dfmt.alignSwitchStatements": {
+          "type": "boolean",
+          "default": true,
+          "description": "Align labels, cases, and defaults with their enclosing switch."
+        },
+        "d.dfmt.braceStyle": {
+          "type": "string",
+          "default": "allman",
+          "description": "Denotes the style for using curly braces in code blocks.",
+          "enum": [
+            "allman",
+            "otbs",
+            "stroustrup"
+          ]
+        },
+        "d.dfmt.endOfLine": {
+          "type": "string",
+          "default": "lf",
+          "description": "Line ending file format.",
+          "enum": [
+            "lf",
+            "cr",
+            "crlf"
+          ]
+        },
+        "d.dfmt.softMaxLineLength": {
+          "type": "number",
+          "default": 80,
+          "description": "The formatting process will usually keep lines below this length."
+        },
+        "d.dfmt.maxLineLength": {
+          "type": "number",
+          "default": 120,
+          "description": "Forces hard line wrapping after the amount of characters specified."
+        },
+        "d.dfmt.outdentAttributes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Decrease the indentation level of attributes."
+        },
+        "d.dfmt.spaceAfterCast": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert space after the closing parenthesis of a cast expression."
+        },
+        "d.dfmt.selectiveImportSpace": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert space after the module name and before the ':' for selective imports."
+        },
+        "d.dfmt.splitOperatorAtLineEnd": {
+          "type": "boolean",
+          "default": false,
+          "description": "Place operators on the end of the previous line when splitting lines."
+        },
+        "d.dfmt.compactLabeledStatements": {
+          "type": "boolean",
+          "default": true,
+          "description": "Place labels on the same line as the labeled switch, for, foreach, or while statement."
+        },
+        "d.dscanner.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling Dscanner.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dfix.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling Dfix.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
+        },
+        "d.dProfileViewer.compiler": {
+          "type": "string",
+          "default": null,
+          "description": "The compiler used by dub when compiling D Profile Viewer.",
+          "enum": [
+            "dmd",
+            "ldc2",
+            "gdc"
+          ]
         }
+      }
     },
-    "scripts": {
-        "vscode:prepublish": "./node_modules/.bin/tsc -p ./",
-        "compile": "./node_modules/.bin/tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "devDependencies": {
-        "typescript": "^2.1.6",
-        "vscode": "^1.0.3",
-        "@types/node": "^7.0.5",
-        "@types/tmp": "^0.0.32",
-        "@types/xml2js": "^0.0.32",
-        "@types/escape-string-regexp": "^0.0.30"
-    },
-    "dependencies": {
-        "meta-pkg": "^0.6.4",
-        "tmp": "^0.0.31",
-        "xml2js": "^0.4.17",
-        "escape-string-regexp": "^1.0.5"
-    },
-    "extensionDependencies": [
-        "LaurentTreguier.sdlang"
-    ]
+    "commands": [
+      {
+        "title": "Create Default Tasks",
+        "category": "Dlang",
+        "command": "dlang.default-tasks"
+      },
+      {
+        "title": "Run Dfix",
+        "category": "Dlang",
+        "command": "dlang.dfix"
+      },
+      {
+        "title": "See Program Profile",
+        "category": "Dlang",
+        "command": "dlang.d-profile-viewer"
+      },
+      {
+        "title": "Add Import Path To DCD",
+        "category": "DCD",
+        "command": "dlang.dcd.import"
+      },
+      {
+        "title": "Init Package",
+        "category": "Dub",
+        "command": "dlang.dub.init"
+      },
+      {
+        "title": "Fetch Package",
+        "category": "Dub",
+        "command": "dlang.dub.fetch"
+      },
+      {
+        "title": "Remove Package",
+        "category": "Dub",
+        "command": "dlang.dub.remove"
+      },
+      {
+        "title": "Upgrade Package Dependencies",
+        "category": "Dub",
+        "command": "dlang.dub.upgrade"
+      },
+      {
+        "title": "Convert Dub File Format",
+        "category": "Dub",
+        "command": "dlang.dub.convert"
+      },
+      {
+        "title": "Dustmite",
+        "category": "Dub",
+        "command": "dlang.dub.dustmite"
+      },
+      {
+        "title": "Change Compiler",
+        "category": "Dlang",
+        "command": "dlang.tasks.compiler"
+      },
+      {
+        "title": "Change Build Type",
+        "category": "Dlang",
+        "command": "dlang.tasks.build"
+      },
+      {
+        "title": "Install Tools",
+        "category": "Dlang",
+        "command": "dlang.install"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "group": "dlang",
+          "command": "dlang.dfix",
+          "when": "resourceLangId == d"
+        }
+      ],
+      "explorer/context": [
+        {
+          "group": "dlang",
+          "command": "dlang.dcd.import"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "./node_modules/.bin/tsc -p ./",
+    "compile": "./node_modules/.bin/tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "@types/escape-string-regexp": "^0.0.30",
+    "@types/glob": "^5.0.30",
+    "@types/mocha": "^2.2.40",
+    "@types/node": "^7.0.5",
+    "@types/tmp": "^0.0.32",
+    "@types/xml2js": "^0.0.32",
+    "glob": "^7.1.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0",
+    "remap-istanbul": "^0.9.1",
+    "typescript": "^2.1.6",
+    "vscode": "^1.0.3"
+  },
+  "dependencies": {
+    "meta-pkg": "^0.6.4",
+    "tmp": "^0.0.31",
+    "xml2js": "^0.4.17",
+    "escape-string-regexp": "^1.0.5"
+  },
+  "extensionDependencies": [
+    "LaurentTreguier.sdlang"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,430 +1,430 @@
 {
-  "name": "dlang",
-  "displayName": "D Language",
-  "description": "Support for the D Programming Language (https://dlang.org/)",
-  "version": "0.10.0",
-  "publisher": "dlang-vscode",
-  "license": "SEE LICENSE IN LICENSE.md",
-  "icon": "images/dlogo.png",
-  "homepage": "https://dlang-vscode.github.io/",
-  "galleryBanner": {
-    "color": "#B03931",
-    "theme": "dark"
-  },
-  "engines": {
-    "vscode": "^1.1.0"
-  },
-  "bugs": {
-    "url": "https://github.com/dlang-vscode/dlang-vscode/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/dlang-vscode/dlang-vscode.git"
-  },
-  "categories": [
-    "Languages",
-    "Snippets",
-    "Formatters",
-    "Linters",
-    "Other"
-  ],
-  "keywords": [
-    "dub",
-    "dcd",
-    "dfmt",
-    "dscanner",
-    "dfix"
-  ],
-  "activationEvents": [
-    "onLanguage:d",
-    "workspaceContains:dub.json",
-    "workspaceContains:dub.sdl",
-    "onCommand:dlang.default-tasks",
-    "onCommand:dlang.install",
-    "onCommand:dlang.d-profile-viewer",
-    "onCommand:dlang.dcd.import",
-    "onCommand:dlang.dub.init",
-    "onCommand:dlang.dub.fetch",
-    "onCommand:dlang.dub.remove",
-    "onCommand:dlang.dub.upgrade",
-    "onCommand:dlang.dub.convert",
-    "onCommand:dlang.dub.dustmite",
-    "onCommand:dlang.tasks.compiler",
-    "onCommand:dlang.tasks.build",
-    "onCommand:dlang.action.dfix"
-  ],
-  "main": "./out/src/extension",
-  "contributes": {
-    "languages": [
-      {
-        "id": "d",
-        "aliases": [
-          "D",
-          "d"
-        ],
-        "extensions": [
-          ".d",
-          ".di"
-        ],
-        "configuration": "./d.configuration.json"
-      }
-    ],
-    "grammars": [
-      {
-        "language": "d",
-        "scopeName": "source.d",
-        "path": "./syntaxes/d.tmLanguage"
-      }
-    ],
-    "snippets": [
-      {
-        "language": "d",
-        "path": "./snippets/snippets.json"
-      }
-    ],
-    "configuration": {
-      "title": "D configuration",
-      "properties": {
-        "d.dmdConf.linux": {
-          "type": "string",
-          "default": "/etc/dmd.conf",
-          "description": "Path to the DMD configuration file on Linux."
-        },
-        "d.dmdConf.osx": {
-          "type": "string",
-          "default": "/usr/local/etc/dmd.conf",
-          "description": "Path to the DMD configuration file on OS X."
-        },
-        "d.dmdConf.windows": {
-          "type": "string",
-          "default": "C:\\D\\dmd2\\windows\\bin\\sc.ini",
-          "description": "Path to the DMD configuration file on Windows."
-        },
-        "d.tools.enabled.dcd": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether DCD is used or not."
-        },
-        "d.tools.enabled.dfmt": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether DFMT is used or not."
-        },
-        "d.tools.enabled.dscanner": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Dscanner is used or not."
-        },
-        "d.tools.enabled.dfix": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether Dfix is used or not."
-        },
-        "d.tools.enabled.dProfileViewer": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether F Profile Viewer is used or not."
-        },
-        "d.tools.dub": {
-          "type": "string",
-          "default": "dub",
-          "description": "Path to the dub executable."
-        },
-        "d.tools.dcd.client": {
-          "type": "string",
-          "default": "dcd-client",
-          "description": "Path to the system DCD client executable (optional)."
-        },
-        "d.tools.dcd.server": {
-          "type": "string",
-          "default": "dcd-server",
-          "description": "Path to the system DCD server executable (optional)."
-        },
-        "d.tools.dfmt": {
-          "type": "string",
-          "default": "dfmt",
-          "description": "Path to the system DFMT executable (optional)."
-        },
-        "d.tools.dscanner": {
-          "type": "string",
-          "default": "dscanner",
-          "description": "Path to the system Dscanner executable (optional)."
-        },
-        "d.tools.dfix": {
-          "type": "string",
-          "default": "dfix",
-          "description": "Path to the system Dfix executable (optional)."
-        },
-        "d.tools.dProfileViewer": {
-          "type": "string",
-          "default": "d-profile-viewer",
-          "description": "Path to the system D Profile Viewer executable (optional)."
-        },
-        "d.dub.compiler": {
-          "type": "string",
-          "default": "dmd",
-          "description": "The compiler used by dub when compiling other tools.",
-          "enum": [
-            "dmd",
-            "ldc2",
-            "gdc"
-          ]
-        },
-        "d.dcd.compiler": {
-          "type": "string",
-          "default": null,
-          "description": "The compiler used by dub when compiling DCD.",
-          "enum": [
-            "dmd",
-            "ldc2",
-            "gdc"
-          ]
-        },
-        "d.dcd.tcp": {
-          "type": "boolean",
-          "default": false,
-          "description": "Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows."
-        },
-        "d.dcd.port": {
-          "type": "number",
-          "default": 9166,
-          "description": "Listens on this port instead of the default port 9166 when TCP sockets are used."
-        },
-        "d.dcd.imports": {
-          "type": "array",
-          "default": [],
-          "description": "An array of paths that DCD should import on launch."
-        },
-        "d.dfmt.compiler": {
-          "type": "string",
-          "default": null,
-          "description": "The compiler used by dub when compiling DFMT.",
-          "enum": [
-            "dmd",
-            "ldc2",
-            "gdc"
-          ]
-        },
-        "d.dfmt.alignSwitchStatements": {
-          "type": "boolean",
-          "default": true,
-          "description": "Align labels, cases, and defaults with their enclosing switch."
-        },
-        "d.dfmt.braceStyle": {
-          "type": "string",
-          "default": "allman",
-          "description": "Denotes the style for using curly braces in code blocks.",
-          "enum": [
-            "allman",
-            "otbs",
-            "stroustrup"
-          ]
-        },
-        "d.dfmt.endOfLine": {
-          "type": "string",
-          "default": "lf",
-          "description": "Line ending file format.",
-          "enum": [
-            "lf",
-            "cr",
-            "crlf"
-          ]
-        },
-        "d.dfmt.softMaxLineLength": {
-          "type": "number",
-          "default": 80,
-          "description": "The formatting process will usually keep lines below this length."
-        },
-        "d.dfmt.maxLineLength": {
-          "type": "number",
-          "default": 120,
-          "description": "Forces hard line wrapping after the amount of characters specified."
-        },
-        "d.dfmt.outdentAttributes": {
-          "type": "boolean",
-          "default": true,
-          "description": "Decrease the indentation level of attributes."
-        },
-        "d.dfmt.spaceAfterCast": {
-          "type": "boolean",
-          "default": true,
-          "description": "Insert space after the closing parenthesis of a cast expression."
-        },
-        "d.dfmt.selectiveImportSpace": {
-          "type": "boolean",
-          "default": true,
-          "description": "Insert space after the module name and before the ':' for selective imports."
-        },
-        "d.dfmt.splitOperatorAtLineEnd": {
-          "type": "boolean",
-          "default": false,
-          "description": "Place operators on the end of the previous line when splitting lines."
-        },
-        "d.dfmt.compactLabeledStatements": {
-          "type": "boolean",
-          "default": true,
-          "description": "Place labels on the same line as the labeled switch, for, foreach, or while statement."
-        },
-        "d.dscanner.compiler": {
-          "type": "string",
-          "default": null,
-          "description": "The compiler used by dub when compiling Dscanner.",
-          "enum": [
-            "dmd",
-            "ldc2",
-            "gdc"
-          ]
-        },
-        "d.dfix.compiler": {
-          "type": "string",
-          "default": null,
-          "description": "The compiler used by dub when compiling Dfix.",
-          "enum": [
-            "dmd",
-            "ldc2",
-            "gdc"
-          ]
-        },
-        "d.dProfileViewer.compiler": {
-          "type": "string",
-          "default": null,
-          "description": "The compiler used by dub when compiling D Profile Viewer.",
-          "enum": [
-            "dmd",
-            "ldc2",
-            "gdc"
-          ]
-        }
-      }
+    "name": "dlang",
+    "displayName": "D Language",
+    "description": "Support for the D Programming Language (https://dlang.org/)",
+    "version": "0.10.0",
+    "publisher": "dlang-vscode",
+    "license": "SEE LICENSE IN LICENSE.md",
+    "icon": "images/dlogo.png",
+    "homepage": "https://dlang-vscode.github.io/",
+    "galleryBanner": {
+        "color": "#B03931",
+        "theme": "dark"
     },
-    "commands": [
-      {
-        "title": "Create Default Tasks",
-        "category": "Dlang",
-        "command": "dlang.default-tasks"
-      },
-      {
-        "title": "Install Tools",
-        "category": "Dlang",
-        "command": "dlang.install"
-      },
-      {
-        "title": "See Program Profile",
-        "category": "Dlang",
-        "command": "dlang.d-profile-viewer"
-      },
-      {
-        "title": "Add Import Path To DCD",
-        "category": "DCD",
-        "command": "dlang.dcd.import"
-      },
-      {
-        "title": "Init Package",
-        "category": "Dub",
-        "command": "dlang.dub.init"
-      },
-      {
-        "title": "Fetch Package",
-        "category": "Dub",
-        "command": "dlang.dub.fetch"
-      },
-      {
-        "title": "Remove Package",
-        "category": "Dub",
-        "command": "dlang.dub.remove"
-      },
-      {
-        "title": "Upgrade Package Dependencies",
-        "category": "Dub",
-        "command": "dlang.dub.upgrade"
-      },
-      {
-        "title": "Convert Dub File Format",
-        "category": "Dub",
-        "command": "dlang.dub.convert"
-      },
-      {
-        "title": "Dustmite",
-        "category": "Dub",
-        "command": "dlang.dub.dustmite"
-      },
-      {
-        "title": "Change Compiler",
-        "category": "Dlang",
-        "command": "dlang.tasks.compiler"
-      },
-      {
-        "title": "Change Build Type",
-        "category": "Dlang",
-        "command": "dlang.tasks.build"
-      },
-      {
-        "title": "Disable Check",
-        "category": "Dlang Actions",
-        "command": "dlang.actions.config"
-      },
-      {
-        "title": "Run Dfix",
-        "category": "Dlang Actions",
-        "command": "dlang.actions.dfix"
-      },
-      {
-        "title": "Replace `delete` With `destroy()`",
-        "category": "Dlang Actions",
-        "command": "dlang.actions.replaceDeletes"
-      },
-      {
-        "title": "Sort Imports",
-        "category": "Dlang Actions",
-        "command": "dlang.actions.sortImports"
-      }
+    "engines": {
+        "vscode": "^1.1.0"
+    },
+    "bugs": {
+        "url": "https://github.com/dlang-vscode/dlang-vscode/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dlang-vscode/dlang-vscode.git"
+    },
+    "categories": [
+        "Languages",
+        "Snippets",
+        "Formatters",
+        "Linters",
+        "Other"
     ],
-    "menus": {
-      "editor/title": [
-        {
-          "group": "dlang",
-          "command": "dlang.actions.dfix",
-          "when": "resourceLangId == d"
+    "keywords": [
+        "dub",
+        "dcd",
+        "dfmt",
+        "dscanner",
+        "dfix"
+    ],
+    "activationEvents": [
+        "onLanguage:d",
+        "workspaceContains:dub.json",
+        "workspaceContains:dub.sdl",
+        "onCommand:dlang.default-tasks",
+        "onCommand:dlang.install",
+        "onCommand:dlang.d-profile-viewer",
+        "onCommand:dlang.dcd.import",
+        "onCommand:dlang.dub.init",
+        "onCommand:dlang.dub.fetch",
+        "onCommand:dlang.dub.remove",
+        "onCommand:dlang.dub.upgrade",
+        "onCommand:dlang.dub.convert",
+        "onCommand:dlang.dub.dustmite",
+        "onCommand:dlang.tasks.compiler",
+        "onCommand:dlang.tasks.build",
+        "onCommand:dlang.action.dfix"
+    ],
+    "main": "./out/src/extension",
+    "contributes": {
+        "languages": [
+            {
+                "id": "d",
+                "aliases": [
+                    "D",
+                    "d"
+                ],
+                "extensions": [
+                    ".d",
+                    ".di"
+                ],
+                "configuration": "./d.configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "d",
+                "scopeName": "source.d",
+                "path": "./syntaxes/d.tmLanguage"
+            }
+        ],
+        "snippets": [
+            {
+                "language": "d",
+                "path": "./snippets/snippets.json"
+            }
+        ],
+        "configuration": {
+            "title": "D configuration",
+            "properties": {
+                "d.dmdConf.linux": {
+                    "type": "string",
+                    "default": "/etc/dmd.conf",
+                    "description": "Path to the DMD configuration file on Linux."
+                },
+                "d.dmdConf.osx": {
+                    "type": "string",
+                    "default": "/usr/local/etc/dmd.conf",
+                    "description": "Path to the DMD configuration file on OS X."
+                },
+                "d.dmdConf.windows": {
+                    "type": "string",
+                    "default": "C:\\D\\dmd2\\windows\\bin\\sc.ini",
+                    "description": "Path to the DMD configuration file on Windows."
+                },
+                "d.tools.enabled.dcd": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether DCD is used or not."
+                },
+                "d.tools.enabled.dfmt": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether DFMT is used or not."
+                },
+                "d.tools.enabled.dscanner": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether Dscanner is used or not."
+                },
+                "d.tools.enabled.dfix": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether Dfix is used or not."
+                },
+                "d.tools.enabled.dProfileViewer": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether F Profile Viewer is used or not."
+                },
+                "d.tools.dub": {
+                    "type": "string",
+                    "default": "dub",
+                    "description": "Path to the dub executable."
+                },
+                "d.tools.dcd.client": {
+                    "type": "string",
+                    "default": "dcd-client",
+                    "description": "Path to the system DCD client executable (optional)."
+                },
+                "d.tools.dcd.server": {
+                    "type": "string",
+                    "default": "dcd-server",
+                    "description": "Path to the system DCD server executable (optional)."
+                },
+                "d.tools.dfmt": {
+                    "type": "string",
+                    "default": "dfmt",
+                    "description": "Path to the system DFMT executable (optional)."
+                },
+                "d.tools.dscanner": {
+                    "type": "string",
+                    "default": "dscanner",
+                    "description": "Path to the system Dscanner executable (optional)."
+                },
+                "d.tools.dfix": {
+                    "type": "string",
+                    "default": "dfix",
+                    "description": "Path to the system Dfix executable (optional)."
+                },
+                "d.tools.dProfileViewer": {
+                    "type": "string",
+                    "default": "d-profile-viewer",
+                    "description": "Path to the system D Profile Viewer executable (optional)."
+                },
+                "d.dub.compiler": {
+                    "type": "string",
+                    "default": "dmd",
+                    "description": "The compiler used by dub when compiling other tools.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                },
+                "d.dcd.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling DCD.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                },
+                "d.dcd.tcp": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Listen on a TCP socket instead of a UNIX domain socket. This switch has no effect on Windows."
+                },
+                "d.dcd.port": {
+                    "type": "number",
+                    "default": 9166,
+                    "description": "Listens on this port instead of the default port 9166 when TCP sockets are used."
+                },
+                "d.dcd.imports": {
+                    "type": "array",
+                    "default": [],
+                    "description": "An array of paths that DCD should import on launch."
+                },
+                "d.dfmt.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling DFMT.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                },
+                "d.dfmt.alignSwitchStatements": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Align labels, cases, and defaults with their enclosing switch."
+                },
+                "d.dfmt.braceStyle": {
+                    "type": "string",
+                    "default": "allman",
+                    "description": "Denotes the style for using curly braces in code blocks.",
+                    "enum": [
+                        "allman",
+                        "otbs",
+                        "stroustrup"
+                    ]
+                },
+                "d.dfmt.endOfLine": {
+                    "type": "string",
+                    "default": "lf",
+                    "description": "Line ending file format.",
+                    "enum": [
+                        "lf",
+                        "cr",
+                        "crlf"
+                    ]
+                },
+                "d.dfmt.softMaxLineLength": {
+                    "type": "number",
+                    "default": 80,
+                    "description": "The formatting process will usually keep lines below this length."
+                },
+                "d.dfmt.maxLineLength": {
+                    "type": "number",
+                    "default": 120,
+                    "description": "Forces hard line wrapping after the amount of characters specified."
+                },
+                "d.dfmt.outdentAttributes": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Decrease the indentation level of attributes."
+                },
+                "d.dfmt.spaceAfterCast": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Insert space after the closing parenthesis of a cast expression."
+                },
+                "d.dfmt.selectiveImportSpace": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Insert space after the module name and before the ':' for selective imports."
+                },
+                "d.dfmt.splitOperatorAtLineEnd": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Place operators on the end of the previous line when splitting lines."
+                },
+                "d.dfmt.compactLabeledStatements": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Place labels on the same line as the labeled switch, for, foreach, or while statement."
+                },
+                "d.dscanner.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling Dscanner.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                },
+                "d.dfix.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling Dfix.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                },
+                "d.dProfileViewer.compiler": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The compiler used by dub when compiling D Profile Viewer.",
+                    "enum": [
+                        "dmd",
+                        "ldc2",
+                        "gdc"
+                    ]
+                }
+            }
+        },
+        "commands": [
+            {
+                "title": "Create Default Tasks",
+                "category": "Dlang",
+                "command": "dlang.default-tasks"
+            },
+            {
+                "title": "Install Tools",
+                "category": "Dlang",
+                "command": "dlang.install"
+            },
+            {
+                "title": "See Program Profile",
+                "category": "Dlang",
+                "command": "dlang.d-profile-viewer"
+            },
+            {
+                "title": "Add Import Path To DCD",
+                "category": "DCD",
+                "command": "dlang.dcd.import"
+            },
+            {
+                "title": "Init Package",
+                "category": "Dub",
+                "command": "dlang.dub.init"
+            },
+            {
+                "title": "Fetch Package",
+                "category": "Dub",
+                "command": "dlang.dub.fetch"
+            },
+            {
+                "title": "Remove Package",
+                "category": "Dub",
+                "command": "dlang.dub.remove"
+            },
+            {
+                "title": "Upgrade Package Dependencies",
+                "category": "Dub",
+                "command": "dlang.dub.upgrade"
+            },
+            {
+                "title": "Convert Dub File Format",
+                "category": "Dub",
+                "command": "dlang.dub.convert"
+            },
+            {
+                "title": "Dustmite",
+                "category": "Dub",
+                "command": "dlang.dub.dustmite"
+            },
+            {
+                "title": "Change Compiler",
+                "category": "Dlang",
+                "command": "dlang.tasks.compiler"
+            },
+            {
+                "title": "Change Build Type",
+                "category": "Dlang",
+                "command": "dlang.tasks.build"
+            },
+            {
+                "title": "Disable Check",
+                "category": "Dlang Actions",
+                "command": "dlang.actions.config"
+            },
+            {
+                "title": "Run Dfix",
+                "category": "Dlang Actions",
+                "command": "dlang.actions.dfix"
+            },
+            {
+                "title": "Replace `delete` With `destroy()`",
+                "category": "Dlang Actions",
+                "command": "dlang.actions.replaceDeletes"
+            },
+            {
+                "title": "Sort Imports",
+                "category": "Dlang Actions",
+                "command": "dlang.actions.sortImports"
+            }
+        ],
+        "menus": {
+            "editor/title": [
+                {
+                    "group": "dlang",
+                    "command": "dlang.actions.dfix",
+                    "when": "resourceLangId == d"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "group": "dlang",
+                    "command": "dlang.dcd.import"
+                }
+            ]
         }
-      ],
-      "explorer/context": [
-        {
-          "group": "dlang",
-          "command": "dlang.dcd.import"
-        }
-      ]
-    }
-  },
-  "scripts": {
-    "vscode:prepublish": "./node_modules/.bin/tsc -p ./",
-    "compile": "./node_modules/.bin/tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test"
-  },
-  "devDependencies": {
-    "@types/escape-string-regexp": "^0.0.30",
-    "@types/fs-extra": "^2.0.0",
-    "@types/glob": "^5.0.30",
-    "@types/mocha": "^2.2.40",
-    "@types/node": "^7.0.10",
-    "@types/tmp": "^0.0.32",
-    "@types/xml2js": "^0.0.33",
-    "decache": "^4.1.0",
-    "glob": "^7.1.1",
-    "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
-    "remap-istanbul": "^0.9.1",
-    "typescript": "^2.2.1",
-    "vscode": "^1.1.0"
-  },
-  "dependencies": {
-    "escape-string-regexp": "^1.0.5",
-    "fs-extra": "^2.1.2",
-    "meta-pkg": "^0.6.4",
-    "tmp": "^0.0.31",
-    "xml2js": "^0.4.17"
-  },
-  "extensionDependencies": [
-    "LaurentTreguier.sdlang"
-  ]
+    },
+    "scripts": {
+        "vscode:prepublish": "./node_modules/.bin/tsc -p ./",
+        "compile": "./node_modules/.bin/tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "node ./node_modules/vscode/bin/test"
+    },
+    "devDependencies": {
+        "@types/escape-string-regexp": "^0.0.30",
+        "@types/fs-extra": "^2.1.0",
+        "@types/glob": "^5.0.30",
+        "@types/mocha": "^2.2.41",
+        "@types/node": "^7.0.13",
+        "@types/tmp": "^0.0.32",
+        "@types/xml2js": "^0.0.33",
+        "decache": "^4.1.0",
+        "glob": "^7.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.2.0",
+        "remap-istanbul": "^0.9.5",
+        "typescript": "^2.2.2",
+        "vscode": "^1.1.0"
+    },
+    "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "fs-extra": "^2.1.2",
+        "meta-pkg": "^0.6.4",
+        "tmp": "^0.0.31",
+        "xml2js": "^0.4.17"
+    },
+    "extensionDependencies": [
+        "LaurentTreguier.sdlang"
+    ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,7 +307,7 @@ export function start(context: vsc.ExtensionContext) {
         });
     }
 
-    registerCommands(context.subscriptions, dub)
+    return registerCommands(context.subscriptions, dub)
         .then(dcdClientTool.setup.bind(dcdClientTool))
         .then(dcdServerTool.setup.bind(dcdServerTool))
         .then(dfmtTool.setup.bind(dfmtTool))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,6 +198,14 @@ export function activate(context: vsc.ExtensionContext) {
             })))
         .then(Promise.all.bind(Promise))
         .then(start.bind(null, context))
+        .then(() => ({
+            dcd: {
+                server: {
+                    start: () => server.start(),
+                    stop: () => server.stop()
+                }
+            }
+        }))
         .catch(console.log.bind(console));
 };
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -106,13 +106,15 @@ export default class Provider extends ev.EventEmitter implements
                 let fix = dscannerUtil.fixes.get(<string>d.code);
                 return Object.assign({ arguments: [d, ...fix.getArgs(document, range)] }, fix.command);
             });
-        let disablers = filteredDiagnostics
-            .filter((d) => dscannerUtil.fixes.get(<string>d.code).checkName)
-            .map((d) => ({
-                title: 'Disable Check: ' + d.code,
-                command: 'dlang.actions.config',
-                arguments: [d.code]
-            }));
+        let disablers = vsc.workspace.rootPath
+            ? filteredDiagnostics
+                .filter((d) => dscannerUtil.fixes.get(<string>d.code).checkName)
+                .map((d) => ({
+                    title: 'Disable Check: ' + d.code,
+                    command: 'dlang.actions.config',
+                    arguments: [d.code]
+                }))
+            : [];
 
         return actions.concat(disablers);
     }

--- a/test/d/dfmt/main.d
+++ b/test/d/dfmt/main.d
@@ -1,0 +1,1 @@
+import std.stdio;void main(){stdout.writeln("Hello world !");}

--- a/test/d/dfmt/spaces-2.d
+++ b/test/d/dfmt/spaces-2.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+  stdout.writeln("Hello world !");
+}

--- a/test/d/dfmt/spaces-4.d
+++ b/test/d/dfmt/spaces-4.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+    stdout.writeln("Hello world !");
+}

--- a/test/d/dfmt/spaces-8.d
+++ b/test/d/dfmt/spaces-8.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+        stdout.writeln("Hello world !");
+}

--- a/test/d/dfmt/tabs.d
+++ b/test/d/dfmt/tabs.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+	stdout.writeln("Hello world !");
+}

--- a/test/dfmt.test.ts
+++ b/test/dfmt.test.ts
@@ -12,8 +12,8 @@ describe('dfmt', function () {
     this.timeout(1500);
 
     before(function (done) {
-        fs.copy(uris.get('main.d').fsPath, util.tmpUri.fsPath, () => {
-            vscode.commands.executeCommand('vscode.open', util.tmpUri)
+        fs.copy(uris.get('main.d').fsPath, util.getTmpUri().fsPath, () => {
+            vscode.commands.executeCommand('vscode.open', util.getTmpUri())
                 .then(() => done());
         });
     });
@@ -24,16 +24,16 @@ describe('dfmt', function () {
 
             it('should format with ' + (n ? `${n} spaces` : 'tabs'), function () {
                 return vscode.commands
-                    .executeCommand('vscode.executeFormatDocumentProvider', util.tmpUri, options)
+                    .executeCommand('vscode.executeFormatDocumentProvider', util.getTmpUri(), options)
                     .then((edits: vscode.TextEdit[]) => {
                         let workspaceEdit = new vscode.WorkspaceEdit();
-                        workspaceEdit.set(util.tmpUri, edits);
+                        workspaceEdit.set(util.getTmpUri(), edits);
                         return vscode.workspace.applyEdit(workspaceEdit);
                     }).then(() => new Promise((resolve) =>
                         fs.readFile(uris.get(n ? `spaces-${n}.d` : 'tabs.d').fsPath, (err, data) => resolve(data))))
                     .then((data) => {
                         let doc = vscode.workspace.textDocuments
-                            .find((doc) => doc.uri.fsPath === util.tmpUri.fsPath);
+                            .find((doc) => doc.uri.fsPath === util.getTmpUri().fsPath);
                         assert.equal(doc.getText(), data.toString());
                     });
             });

--- a/test/dfmt.test.ts
+++ b/test/dfmt.test.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as util from './util';
+
+const spacings = [0, 2, 4, 8];
+const uris = util.uris('dfmt', ['main.d', 'tabs.d'].concat(spacings.map((n) => `spaces-${n}.d`)));
+
+describe('dfmt', function () {
+    this.slow(500);
+    this.timeout(1500);
+
+    before(function (done) {
+        fs.copy(uris.get('main.d').fsPath, util.tmpUri.fsPath, () => {
+            vscode.commands.executeCommand('vscode.open', util.tmpUri)
+                .then(() => done());
+        });
+    });
+
+    spacings.forEach((n) => {
+        context('with ' + (n ? `${n} spaces` : 'tabs'), function () {
+            const options = { insertSpaces: n !== 0, tabSize: n };
+
+            it('should format with ' + (n ? `${n} spaces` : 'tabs'), function () {
+                return vscode.commands
+                    .executeCommand('vscode.executeFormatDocumentProvider', util.tmpUri, options)
+                    .then((edits: vscode.TextEdit[]) => {
+                        let workspaceEdit = new vscode.WorkspaceEdit();
+                        workspaceEdit.set(util.tmpUri, edits);
+                        return vscode.workspace.applyEdit(workspaceEdit);
+                    }).then(() => new Promise((resolve) =>
+                        fs.readFile(uris.get(n ? `spaces-${n}.d` : 'tabs.d').fsPath, (err, data) => resolve(data))))
+                    .then((data) => {
+                        let doc = vscode.workspace.textDocuments
+                            .find((doc) => doc.uri.fsPath === util.tmpUri.fsPath);
+                        assert.equal(doc.getText(), data.toString());
+                    });
+            });
+        });
+    });
+});

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,21 @@
+//
+// Note: This example test is leveraging the Mocha test framework.
+// Please refer to their documentation on https://mochajs.org/ for help.
+//
+
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+
+// Defines a Mocha test suite to group tests of similar kind together
+suite("Extension Tests", () => {
+
+    // Defines a Mocha unit test
+    test("Create Default Tasks commands can be executed", async () => {
+        await vscode.commands.executeCommand("dlang.default-tasks");
+        assert(true);
+    });
+});

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -14,8 +14,7 @@ import * as vscode from 'vscode';
 suite("Extension Tests", () => {
 
     // Defines a Mocha unit test
-    test("Create Default Tasks commands can be executed", async () => {
-        await vscode.commands.executeCommand("dlang.default-tasks");
+    test("Pass through", () => {
         assert(true);
     });
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -3,22 +3,17 @@ import * as vscode from 'vscode';
 import * as tmp from 'tmp';
 import * as util from './util';
 
-const extension = vscode.extensions.getExtension('dlang-vscode.dlang');
-
 before(function (done) {
     this.timeout(0);
-    extension.activate()
-        .then(() => new Promise((resolve) =>
-            tmp.tmpName({ postfix: '.d' }, (err, path) => {
-                util.setTmpUri(path);
-                resolve();
-            })))
-        .then(() => done());
+    util.extension.activate().then(() => tmp.tmpName({ postfix: '.d' }, (err, path) => {
+        util.setTmpUri(path);
+        done();
+    }));
 });
 
 after(function (done) {
     this.timeout(0);
-    extension.exports.dcd.server.stop();
+    util.extension.exports.dcd.server.stop();
     vscode.commands.executeCommand('workbench.action.closeActiveEditor')
-        .then(() => fs.unlink(util.tmpUri.fsPath, done));
+        .then(() => fs.unlink(util.getTmpUri().fsPath, done));
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,19 +1,23 @@
-//
-// Note: This example test is leveraging the Mocha test framework.
-// Please refer to their documentation on https://mochajs.org/ for help.
-//
-
-// The module 'assert' provides assertion methods from node
-import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
+import * as fs from 'fs';
 import * as vscode from 'vscode';
+import * as tmp from 'tmp';
+import * as util from './util';
 
-// Defines a Mocha test suite to group tests of similar kind together
-suite("Extension Tests", () => {
-    // Defines a Mocha unit test
-    test("Pass through", () => {
-        assert(true);
-    });
+const extension = vscode.extensions.getExtension('dlang-vscode.dlang');
+
+before(function (done) {
+    this.timeout(0);
+    extension.activate()
+        .then(() => new Promise((resolve) =>
+            tmp.tmpName({ postfix: '.d' }, (err, path) => {
+                util.setTmpUri(path);
+                resolve();
+            })))
+        .then(() => done());
+});
+
+after(function (done) {
+    this.timeout(0);
+    extension.exports.dcd.server.stop();
+    fs.unlink(util.tmpUri.fsPath, done);
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -12,7 +12,6 @@ import * as vscode from 'vscode';
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Extension Tests", () => {
-
     // Defines a Mocha unit test
     test("Pass through", () => {
         assert(true);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -19,5 +19,6 @@ before(function (done) {
 after(function (done) {
     this.timeout(0);
     extension.exports.dcd.server.stop();
-    fs.unlink(util.tmpUri.fsPath, done);
+    vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+        .then(() => fs.unlink(util.tmpUri.fsPath, done));
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,218 @@
+"use strict";
+
+import * as fs from "fs";
+import * as glob from "glob";
+import * as paths from "path";
+
+const istanbul = require("istanbul");
+const Mocha = require("mocha");
+const remapIstanbul = require("remap-istanbul");
+
+// Linux: prevent a weird NPE when mocha on Linux requires the window size from the TTY
+// Since we are not running in a tty environment, we just implementt he method statically
+const tty = require("tty");
+if (!tty.getWindowSize) {
+    tty.getWindowSize = (): number[] => {
+        return [80, 75];
+    };
+}
+
+let mocha = new Mocha({
+    ui: "tdd",
+    useColors: true,
+});
+
+function configure(mochaOpts): void {
+    mocha = new Mocha(mochaOpts);
+}
+exports.configure = configure;
+
+function _mkDirIfExists(dir: string): void {
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+    }
+}
+
+function _readCoverOptions(testsRoot: string): ITestRunnerOptions {
+    let coverConfigPath = paths.join(testsRoot, "..", "..", "coverconfig.json");
+    let coverConfig: ITestRunnerOptions = undefined;
+    if (fs.existsSync(coverConfigPath)) {
+        let configContent = fs.readFileSync(coverConfigPath, "utf-8");
+        coverConfig = JSON.parse(configContent);
+    }
+    return coverConfig;
+}
+
+function run(testsRoot, clb): any {
+    // Enable source map support
+    require("source-map-support").install();
+
+    // Read configuration for the coverage file
+    let coverOptions: ITestRunnerOptions = _readCoverOptions(testsRoot);
+    if (coverOptions && coverOptions.enabled) {
+        // Setup coverage pre-test, including post-test hook to report
+        let coverageRunner = new CoverageRunner(coverOptions, testsRoot, clb);
+        coverageRunner.setupCoverage();
+    }
+
+    // Glob test files
+    glob("**/**.test.js", { cwd: testsRoot }, (error, files): any => {
+        if (error) {
+            return clb(error);
+        }
+        try {
+            // Fill into Mocha
+            files.forEach((f): Mocha => {
+                return mocha.addFile(paths.join(testsRoot, f));
+            });
+            // Run the tests
+            let failureCount = 0;
+
+            mocha.run()
+                .on("fail", (test, err): void => {
+                failureCount++;
+            })
+            .on("end", (): void => {
+                clb(undefined, failureCount);
+            });
+        } catch (error) {
+            return clb(error);
+        }
+    });
+}
+exports.run = run;
+
+interface ITestRunnerOptions {
+    enabled?: boolean;
+    relativeCoverageDir: string;
+    relativeSourcePath: string;
+    ignorePatterns: string[];
+    includePid?: boolean;
+    reports?: string[];
+    verbose?: boolean;
+}
+
+class CoverageRunner {
+
+    private coverageVar: string = "$$cov_" + new Date().getTime() + "$$";
+    private transformer: any = undefined;
+    private matchFn: any = undefined;
+    private instrumenter: any = undefined;
+
+    constructor(private options: ITestRunnerOptions, private testsRoot: string, private endRunCallback: any) {
+        if (!options.relativeSourcePath) {
+            return endRunCallback("Error - relativeSourcePath must be defined for code coverage to work");
+        }
+
+    }
+
+    public setupCoverage(): void {
+        // Set up Code Coverage, hooking require so that instrumented code is returned
+        let self = this;
+        self.instrumenter = new istanbul.Instrumenter({ coverageVariable: self.coverageVar });
+        let sourceRoot = paths.join(self.testsRoot, self.options.relativeSourcePath);
+
+        // Glob source files
+        let srcFiles = glob.sync("**/**.js", {
+            cwd: sourceRoot,
+            ignore: self.options.ignorePatterns,
+        });
+
+        // Create a match function - taken from the run-with-cover.js in istanbul.
+        let decache = require("decache");
+        let fileMap = {};
+        srcFiles.forEach( (file) => {
+            let fullPath = paths.join(sourceRoot, file);
+            fileMap[fullPath] = true;
+
+            // On Windows, extension is loaded pre-test hooks and this mean we lose
+            // our chance to hook the Require call. In order to instrument the code
+            // we have to decache the JS file so on next load it gets instrumented.
+            // This doesn"t impact tests, but is a concern if we had some integration
+            // tests that relied on VSCode accessing our module since there could be
+            // some shared global state that we lose.
+            decache(fullPath);
+        });
+
+        self.matchFn = (file): boolean => { return fileMap[file]; };
+        self.matchFn.files = Object.keys(fileMap);
+
+        // Hook up to the Require function so that when this is called, if any of our source files
+        // are required, the instrumented version is pulled in instead. These instrumented versions
+        // write to a global coverage variable with hit counts whenever they are accessed
+        self.transformer = self.instrumenter.instrumentSync.bind(self.instrumenter);
+        let hookOpts = { verbose: false, extensions: [".js"]};
+        istanbul.hook.hookRequire(self.matchFn, self.transformer, hookOpts);
+
+        // initialize the global variable to stop mocha from complaining about leaks
+        global[self.coverageVar] = {};
+
+        // Hook the process exit event to handle reporting
+        // Only report coverage if the process is exiting successfully
+        process.on("exit", (code) => {
+            self.reportCoverage();
+        });
+    }
+
+    /**
+     * Writes a coverage report. Note that as this is called in the process exit callback, all calls must be synchronous.
+     *
+     * @returns {void}
+     *
+     * @memberOf CoverageRunner
+     */
+    public reportCoverage(): void {
+        let self = this;
+        istanbul.hook.unhookRequire();
+        let cov: any;
+        if (typeof global[self.coverageVar] === "undefined" || Object.keys(global[self.coverageVar]).length === 0) {
+            console.error("No coverage information was collected, exit without writing coverage information");
+            return;
+        } else {
+            cov = global[self.coverageVar];
+        }
+
+        // TODO consider putting this under a conditional flag
+        // Files that are not touched by code ran by the test runner is manually instrumented, to
+        // illustrate the missing coverage.
+        self.matchFn.files.forEach( (file) => {
+            if (!cov[file]) {
+                self.transformer(fs.readFileSync(file, "utf-8"), file);
+
+                // When instrumenting the code, istanbul will give each FunctionDeclaration a value of 1 in coverState.s,
+                // presumably to compensate for function hoisting. We need to reset this, as the function was not hoisted,
+                // as it was never loaded.
+                Object.keys(self.instrumenter.coverState.s).forEach( (key) => {
+                    self.instrumenter.coverState.s[key] = 0;
+                });
+
+                cov[file] = self.instrumenter.coverState;
+            }
+        });
+
+        // TODO Allow config of reporting directory with
+        let reportingDir = paths.join(self.testsRoot, self.options.relativeCoverageDir);
+        let includePid = self.options.includePid;
+        let pidExt = includePid ? ("-" + process.pid) : "";
+        let coverageFile = paths.resolve(reportingDir, "coverage" + pidExt + ".json");
+
+        _mkDirIfExists(reportingDir); // yes, do this again since some test runners could clean the dir initially created
+
+        fs.writeFileSync(coverageFile, JSON.stringify(cov), "utf8");
+
+        let remappedCollector = remapIstanbul.remap(cov, {warn: warning => {
+            // We expect some warnings as any JS file without a typescript mapping will cause this.
+            // By default, we"ll skip printing these to the console as it clutters it up
+            if (self.options.verbose) {
+                console.warn(warning);
+            }
+        }});
+
+        let reporter = new istanbul.Reporter(undefined, reportingDir);
+        let reportTypes = (self.options.reports instanceof Array) ? self.options.reports : ["lcov"];
+        reporter.addAll(reportTypes);
+        reporter.write(remappedCollector, true, () => {
+            console.log(`reports written to ${reportingDir}`);
+        });
+    }
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -9,7 +9,7 @@ const Mocha = require("mocha");
 const remapIstanbul = require("remap-istanbul");
 
 // Linux: prevent a weird NPE when mocha on Linux requires the window size from the TTY
-// Since we are not running in a tty environment, we just implementt he method statically
+// Since we are not running in a tty environment, we just implement the method statically
 const tty = require("tty");
 if (!tty.getWindowSize) {
     tty.getWindowSize = (): number[] => {
@@ -18,7 +18,7 @@ if (!tty.getWindowSize) {
 }
 
 let mocha = new Mocha({
-    ui: "tdd",
+    ui: "bdd",
     useColors: true,
 });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -70,11 +70,11 @@ function run(testsRoot, clb): any {
 
             mocha.run()
                 .on("fail", (test, err): void => {
-                failureCount++;
-            })
-            .on("end", (): void => {
-                clb(undefined, failureCount);
-            });
+                    failureCount++;
+                })
+                .on("end", (): void => {
+                    clb(undefined, failureCount);
+                });
         } catch (error) {
             return clb(error);
         }
@@ -121,7 +121,7 @@ class CoverageRunner {
         // Create a match function - taken from the run-with-cover.js in istanbul.
         let decache = require("decache");
         let fileMap = {};
-        srcFiles.forEach( (file) => {
+        srcFiles.forEach((file) => {
             let fullPath = paths.join(sourceRoot, file);
             fileMap[fullPath] = true;
 
@@ -141,7 +141,7 @@ class CoverageRunner {
         // are required, the instrumented version is pulled in instead. These instrumented versions
         // write to a global coverage variable with hit counts whenever they are accessed
         self.transformer = self.instrumenter.instrumentSync.bind(self.instrumenter);
-        let hookOpts = { verbose: false, extensions: [".js"]};
+        let hookOpts = { verbose: false, extensions: [".js"] };
         istanbul.hook.hookRequire(self.matchFn, self.transformer, hookOpts);
 
         // initialize the global variable to stop mocha from complaining about leaks
@@ -175,14 +175,14 @@ class CoverageRunner {
         // TODO consider putting this under a conditional flag
         // Files that are not touched by code ran by the test runner is manually instrumented, to
         // illustrate the missing coverage.
-        self.matchFn.files.forEach( (file) => {
+        self.matchFn.files.forEach((file) => {
             if (!cov[file]) {
                 self.transformer(fs.readFileSync(file, "utf-8"), file);
 
                 // When instrumenting the code, istanbul will give each FunctionDeclaration a value of 1 in coverState.s,
                 // presumably to compensate for function hoisting. We need to reset this, as the function was not hoisted,
                 // as it was never loaded.
-                Object.keys(self.instrumenter.coverState.s).forEach( (key) => {
+                Object.keys(self.instrumenter.coverState.s).forEach((key) => {
                     self.instrumenter.coverState.s[key] = 0;
                 });
 
@@ -200,13 +200,15 @@ class CoverageRunner {
 
         fs.writeFileSync(coverageFile, JSON.stringify(cov), "utf8");
 
-        let remappedCollector = remapIstanbul.remap(cov, {warn: warning => {
-            // We expect some warnings as any JS file without a typescript mapping will cause this.
-            // By default, we"ll skip printing these to the console as it clutters it up
-            if (self.options.verbose) {
-                console.warn(warning);
+        let remappedCollector = remapIstanbul.remap(cov, {
+            warn: warning => {
+                // We expect some warnings as any JS file without a typescript mapping will cause this.
+                // By default, we"ll skip printing these to the console as it clutters it up
+                if (self.options.verbose) {
+                    console.warn(warning);
+                }
             }
-        }});
+        });
 
         let reporter = new istanbul.Reporter(undefined, reportingDir);
         let reportTypes = (self.options.reports instanceof Array) ? self.options.reports : ["lcov"];

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,20 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as tmp from 'tmp';
+
+let tmpUri: vscode.Uri;
+
+export { tmpUri };
+
+export function setTmpUri(path: string) {
+    tmpUri = vscode.Uri.file(path);
+};
+
+export function uris(test: string, files: string[]) {
+    let result = new Map<string, vscode.Uri>();
+
+    files.forEach((file) =>
+        result.set(file, vscode.Uri.file(path.join(vscode.workspace.rootPath, test, file))));
+
+    return result;
+}

--- a/test/util.ts
+++ b/test/util.ts
@@ -2,9 +2,15 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as tmp from 'tmp';
 
+const extension = vscode.extensions.getExtension('dlang-vscode.dlang');
+
+export { extension };
+
 let tmpUri: vscode.Uri;
 
-export { tmpUri };
+export function getTmpUri() {
+    return tmpUri;
+}
 
 export function setTmpUri(path: string) {
     tmpUri = vscode.Uri.file(path);
@@ -13,8 +19,10 @@ export function setTmpUri(path: string) {
 export function uris(test: string, files: string[]) {
     let result = new Map<string, vscode.Uri>();
 
-    files.forEach((file) =>
-        result.set(file, vscode.Uri.file(path.join(vscode.workspace.rootPath, test, file))));
+    files.forEach((file) => {
+        let p = path.join(extension.extensionPath, 'test', 'd', test, file);
+        result.set(file, vscode.Uri.file(p))
+    });
 
     return result;
 }


### PR DESCRIPTION
With this PR we are going to have:

 - A testing framework that will be called using `npm test`
 - Code Coverage using [codecov.io](https://github.com/dlang-vscode/dlang-vscode). Data is pushed using travis.ci (appveyor is kept for unstable builds)