### PR TITLE
Fix a few things

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.1.0"
+        "vscode": "^1.11.0"
     },
     "bugs": {
         "url": "https://github.com/dlang-vscode/dlang-vscode/issues"
@@ -402,16 +402,16 @@
     },
     "devDependencies": {
         "@types/escape-string-regexp": "^0.0.30",
-        "@types/fs-extra": "^0.0.37",
-        "@types/node": "^7.0.8",
+        "@types/fs-extra": "^2.0.0",
+        "@types/node": "^7.0.12",
         "@types/tmp": "^0.0.32",
         "@types/xml2js": "^0.0.33",
-        "typescript": "^2.2.1",
+        "typescript": "^2.2.2",
         "vscode": "^1.1.0"
     },
     "dependencies": {
         "escape-string-regexp": "^1.0.5",
-        "fs-extra": "^2.0.0",
+        "fs-extra": "^2.1.2",
         "meta-pkg": "^0.6.4",
         "tmp": "^0.0.31",
         "xml2js": "^0.4.17"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,42 @@
                 "path": "./snippets/snippets.json"
             }
         ],
+        "problemMatchers": [
+            {
+                "name": "dub-build",
+                "fileLocation": [
+                    "relative",
+                    "${workspaceRoot}"
+                ],
+                "pattern": "$dub-build"
+            },
+            {
+                "name": "dub-test",
+                "fileLocation": [
+                    "relative",
+                    "${workspaceRoot}"
+                ],
+                "pattern": "$dub-test"
+            }
+        ],
+        "problemPatterns": [
+            {
+                "name": "dub-build",
+                "regexp": "^(.+\\.di?)\\D(\\d+)(?:,|:)?(\\d+)?\\S+\\s+([Ee]rror|[Ww]arning):\\s+(.+)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "severity": 4,
+                "message": 5
+            },
+            {
+                "name": "dub-test",
+                "regexp": "^.+@(.+\\.di?)\\((\\d+)\\S+\\s+(.+)$",
+                "file": 1,
+                "location": 2,
+                "message": 3
+            }
+        ],
         "configuration": {
             "title": "D configuration",
             "properties": {

--- a/packages/dmd.json
+++ b/packages/dmd.json
@@ -1,8 +1,7 @@
 {
     "name": "dmd",
     "targets": [
-        "dmd",
-        "rdmd"
+        "dmd"
     ],
     "backends": {
         "packagekit": "dmd",

--- a/packages/gdc.json
+++ b/packages/gdc.json
@@ -1,7 +1,8 @@
 {
     "name": "gdc",
     "targets": [
-        "gdc"
+        "gdc",
+        "gdmd"
     ],
     "backends": {
         "packagekit": "gdc"

--- a/src/dcd/client.ts
+++ b/src/dcd/client.ts
@@ -1,13 +1,10 @@
 'use strict';
 
 import * as ev from 'events';
-import * as os from 'os';
-import * as fs from 'fs';
 import * as path from 'path';
 import * as cp from 'child_process';
 import * as rl from 'readline';
 import * as vsc from 'vscode';
-import Server from './server';
 import * as util from './util';
 
 export default class Client extends ev.EventEmitter {
@@ -90,16 +87,13 @@ export default class Client extends ev.EventEmitter {
                     let filename = parts[0];
 
                     if (filename === 'stdin') {
-                        documentThenable = new Promise((res) => {
-                            res(this._document);
-                        });
+                        documentThenable = new Promise((res) => res(this._document));
                     } else {
                         documentThenable = vsc.workspace.openTextDocument(filename);
                     }
 
-                    documentThenable.then((document) => {
-                        resolve(new vsc.Location(document.uri, document.positionAt(Number(parts[1]))));
-                    });
+                    documentThenable.then((document) =>
+                        resolve(new vsc.Location(document.uri, document.positionAt(Number(parts[1])))));
 
                     break;
 
@@ -162,9 +156,8 @@ export default class Client extends ev.EventEmitter {
         let lineArgs = line.substring(line.lastIndexOf('(') + 1, line.lastIndexOf(')')).split(/\s*,\s*/);
         let information = new vsc.SignatureInformation(line);
 
-        lineArgs.forEach((arg) => {
-            information.parameters.push(new vsc.ParameterInformation(arg));
-        });
+        information.parameters = information.parameters
+            .concat(lineArgs.map((arg) => new vsc.ParameterInformation(arg)));
 
         return information;
     }

--- a/src/dcd/server.ts
+++ b/src/dcd/server.ts
@@ -30,9 +30,8 @@ export default class Server {
                 : path.join(vsc.workspace.rootPath, i)));
 
         if (vsc.workspace.rootPath) {
-            this.getImportDirs(vsc.workspace.rootPath).forEach((dir) => {
-                additionsImports.push('-I' + dir);
-            });
+            this.getImportDirs(vsc.workspace.rootPath)
+                .forEach((dir) => additionsImports.push('-I' + dir));
         }
 
         try {
@@ -48,18 +47,15 @@ export default class Server {
             let conf = fs.readFileSync(configFile).toString();
             let result = conf.match(/-I[^\s"]+/g);
 
-            result.forEach((match) => {
-                additionsImports.push(match.replace('%@P%', path.dirname(configFile)));
-            });
+            additionsImports = additionsImports
+                .concat(result.map((match) => match.replace('%@P%', path.dirname(configFile))));
         } catch (e) { }
 
         let args = ['--logLevel', 'off'].concat(util.getTcpArgs());
         let server = cp.spawn(path.join(Server.toolDirectory, Server.toolFile), additionsImports.concat(args), { stdio: 'ignore' });
         Server._instanceLaunched = true;
 
-        server.on('exit', () => {
-            Server._instanceLaunched = false;
-        });
+        server.on('exit', () => Server._instanceLaunched = false);
     }
 
     public stop() {
@@ -108,17 +104,14 @@ export default class Server {
                         });
 
                         if (importPath) {
-                            this.getImportDirs(importPath).forEach((dir) => {
-                                clients.push(this.importPath(dir));
-                            });
+                            this.getImportDirs(importPath)
+                                .forEach((dir) => clients.push(this.importPath(dir)));
                         }
                     }
 
-                    Promise.all(clients.map((client) => {
-                        return new Promise((res) => {
-                            client.on('exit', res);
-                        });
-                    })).then(resolve);
+                    Promise.all(clients
+                        .map((client) => new Promise((res) => client
+                            .on('exit', res)))).then(resolve);
                 });
             });
         });
@@ -146,9 +139,7 @@ export default class Server {
                 allPackages.forEach((p) => {
                     if (p instanceof String) {
                         let impAdded = this.getImportDirs(path.join(dubPath, <string>p));
-                        impAdded.forEach((newP) => {
-                            imp.add(newP);
-                        });
+                        impAdded.forEach((newP) => imp.add(newP));
                     } else {
                         [
                             p.sourcePaths,
@@ -169,7 +160,7 @@ export default class Server {
                     } catch (e) { }
                 });
             } catch (e) { }
-        })
+        });
 
         return imp;
     }

--- a/src/dcd/util.ts
+++ b/src/dcd/util.ts
@@ -35,4 +35,4 @@ export function getTcpArgs() {
     return vsc.workspace.getConfiguration().get('d.dcd.tcp')
         ? ['--tcp', '--port', String(vsc.workspace.getConfiguration().get('d.dcd.port'))]
         : [];
-}
+};

--- a/src/dcd/util.ts
+++ b/src/dcd/util.ts
@@ -6,14 +6,14 @@ const types = new Map<string, vsc.CompletionItemKind>();
 
 types.set('c', vsc.CompletionItemKind.Class);
 types.set('i', vsc.CompletionItemKind.Interface);
-types.set('s', vsc.CompletionItemKind.Class);
+types.set('s', vsc.CompletionItemKind.Struct);
 types.set('u', vsc.CompletionItemKind.Enum);
 types.set('v', vsc.CompletionItemKind.Variable);
 types.set('m', vsc.CompletionItemKind.Field);
 types.set('k', vsc.CompletionItemKind.Keyword);
 types.set('f', vsc.CompletionItemKind.Function);
 types.set('g', vsc.CompletionItemKind.Enum);
-types.set('e', vsc.CompletionItemKind.Field);
+types.set('e', vsc.CompletionItemKind.EnumMember);
 types.set('P', vsc.CompletionItemKind.Module);
 types.set('M', vsc.CompletionItemKind.Module);
 types.set('a', vsc.CompletionItemKind.Value);

--- a/src/dfmt.ts
+++ b/src/dfmt.ts
@@ -34,11 +34,9 @@ export default class Dfmt {
             'selectiveImportSpace',
             'splitOperatorAtLineEnd',
             'compactLabeledStatements'
-        ].forEach((attr) => {
-            args.push('--' + attr.replace(/[A-Z]/g, (found) => {
-                return '_' + found.toLowerCase();
-            }), String(vsc.workspace.getConfiguration().get('d.dfmt.' + attr)));
-        });
+        ].forEach((attr) =>
+            args.push('--' + attr.replace(/[A-Z]/g, (found) => '_' + found.toLowerCase()),
+                String(vsc.workspace.getConfiguration().get('d.dfmt.' + attr))));
 
         this._dfmt = cp.spawn(path.join(Dfmt.toolDirectory, Dfmt.toolFile), args);
     }
@@ -51,10 +49,7 @@ export default class Dfmt {
             reject();
         });
 
-        this._dfmt.stdout.on('data', (data) => {
-            output += data;
-        });
-
+        this._dfmt.stdout.on('data', (data) => output += data);
         this._dfmt.stdout.on('close', () => {
             let lastLine = this._document.lineCount - 1;
             let lastCol = this._document.lineAt(lastLine).text.length;

--- a/src/dscanner/dscanner.ts
+++ b/src/dscanner/dscanner.ts
@@ -58,11 +58,7 @@ export default class Dscanner {
         }
 
         this._dscanner = cp.spawn(path.join(Dscanner.toolDirtory, Dscanner.toolFile), args);
-
-        this._dscanner.stdout.on('data', (data) => {
-            output += data.toString();
-        });
-
+        this._dscanner.stdout.on('data', (data) => output += data.toString());
         this._dscanner.stdout.on('close', () => {
             try {
                 let report: rep.Report = JSON.parse(output.replace(/\\\\"/g, '\\"'));

--- a/src/dscanner/util.ts
+++ b/src/dscanner/util.ts
@@ -119,7 +119,7 @@ fixes.set('dscanner.style.imports_sortedness', {
             for (let i = 1; linesAdded; ++i) {
                 linesAdded = false;
 
-                for (let sign = -1; sign <= 1; sign += 2) {
+                [-1, 1].forEach((sign) => {
                     if (startLineNum + sign * i >= 0
                         && startLineNum + sign * i < editor.document.lineCount) {
                         line = editor.document.lineAt(startLineNum + sign * i);
@@ -130,7 +130,7 @@ fixes.set('dscanner.style.imports_sortedness', {
                             linesAdded = true;
                         }
                     }
-                }
+                });
             }
 
             let numbers = Array.from(numberedLines.keys()).sort();

--- a/src/dub.ts
+++ b/src/dub.ts
@@ -26,8 +26,14 @@ export default class Dub extends vsc.Disposable {
         return this.launchCommand('init', [], vsc.workspace.rootPath, { stdin: entries.join(os.EOL) });
     }
 
-    public fetch(packageName: string) {
-        return this.launchCommand('fetch', [packageName]);
+    public fetch(packageName: string, version?: string) {
+        let args = [packageName];
+
+        if (version) {
+            args.push('--version=' + version);
+        }
+
+        return this.launchCommand('fetch', args);
     }
 
     public remove(packageName: string, version?: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,7 @@ export function activate(context: vsc.ExtensionContext) {
         .then((packagesStrings: string[]) => packagesStrings.map(JSON.parse.bind(JSON)))
         .then((packages: mpkg.Package[]) => packages.forEach(mpkg.registerPackage.bind(mpkg)))
         .then(() => packageNames.map(mpkg.getInstallers.bind(mpkg)))
-        .then(Promise.all.bind(Promise))
+        .then((promises) => Promise.all(promises))
         .then((allInstallers: mpkg.Installer[][]) => {
             allInstallers.forEach((installers, i) => {
                 if (installers.length) {
@@ -175,10 +175,10 @@ export function activate(context: vsc.ExtensionContext) {
                     }
                 });
         }).then(() => packageNames.map(mpkg.isInstalled.bind(mpkg)))
-        .then(Promise.all.bind(Promise))
+        .then((promises) => Promise.all(promises))
         .then((installed: boolean[]) => packageNames
             .map((name, i) => installed[i] ? mpkg.isUpgradable(name) : false))
-        .then(Promise.all.bind(Promise))
+        .then((promises) => Promise.all(promises))
         .then((upgrades: boolean[]) => packageNames.filter((name, i) => upgrades[i]))
         .then((upgradablePackages: string[]) => upgradablePackages
             .map((name) => vsc.window.showInformationMessage(name + ' can be upgraded',
@@ -198,7 +198,7 @@ export function activate(context: vsc.ExtensionContext) {
                             results.name + ' was upgraded'));
                 }
             })))
-        .then(Promise.all.bind(Promise))
+        .then((promises) => Promise.all(promises))
         .then(start.bind(null, context))
         .catch(console.log.bind(console));
 };
@@ -209,7 +209,7 @@ export function deactivate() {
     }
 };
 
-export function start(context: vsc.ExtensionContext) {
+function start(context: vsc.ExtensionContext) {
     tasks = new Tasks();
 
     let dub = new Dub(output);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,9 @@ class Tool {
     }
 
     public fetch() {
-        return Tool.dub.fetch(this._name);
+        return Tool.dub.search(this._name)
+            .then((packages) => packages.find((pkg) => pkg.name === this._name))
+            .then((pkg) => Tool.dub.fetch(this._name, pkg ? pkg.version : undefined));
     }
 
     public build() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,7 @@ const initOptions = [
     {
         prompt: 'The name of the package',
         placeHolder: 'Name',
-        value: path.basename(vsc.workspace.rootPath)
+        value: vsc.workspace.rootPath ? path.basename(vsc.workspace.rootPath) : ''
     },
     {
         prompt: 'Brief description of the package',
@@ -210,13 +210,16 @@ export function deactivate() {
 };
 
 function start(context: vsc.ExtensionContext) {
-    tasks = new Tasks();
+    if (vsc.workspace.rootPath) {
+        tasks = new Tasks();
+        context.subscriptions.push(tasks);
+    }
 
     let dub = new Dub(output);
     let provider = new Provider();
 
     output.show(true);
-    context.subscriptions.push(tasks, output, dub);
+    context.subscriptions.push(output, dub);
 
     let dcdClientTool = new Tool('dcd', { buildConfig: 'client' });
     let dcdServerTool = new Tool('dcd', { buildConfig: 'server' });
@@ -246,12 +249,17 @@ function start(context: vsc.ExtensionContext) {
         provider.on('restart', () => {
             output.appendLine('DCD : restarting server...');
             server.start();
-            server.importSelections(context.subscriptions);
+
+            if (vsc.workspace.rootPath) {
+                server.importSelections(context.subscriptions);
+            }
         });
 
         context.subscriptions.push(completionProvider, signatureProvider, definitionProvider, hoverProvider);
 
-        return server.importSelections(context.subscriptions);
+        if (vsc.workspace.rootPath) {
+            return server.importSelections(context.subscriptions);
+        }
     };
 
     dfmtTool.activate = () => {
@@ -282,25 +290,11 @@ function start(context: vsc.ExtensionContext) {
         context.subscriptions.push(documentSymbolProvider, workspaceSymbolProvider, codeActionsProvider, diagnosticCollection);
     };
 
-    let tasksFile = path.join(vsc.workspace.rootPath, '.vscode', 'tasks.json');
-
-    registerCommands(context.subscriptions, dub)
-        .then(dcdClientTool.setup.bind(dcdClientTool))
-        .then(dcdServerTool.setup.bind(dcdServerTool))
-        .then(dfmtTool.setup.bind(dfmtTool))
-        .then(dscannerTool.setup.bind(dscannerTool))
-        .then(() => {
-            let tasksWatcher = vsc.workspace.createFileSystemWatcher(tasksFile);
-
-            tasksWatcher.onDidCreate(tasks.showChoosers.bind(tasks), null, context.subscriptions);
-            tasksWatcher.onDidChange(tasks.updateChoosers.bind(tasks), null, context.subscriptions);
-            tasksWatcher.onDidDelete(tasks.hideChoosers.bind(tasks), null, context.subscriptions);
-            tasks.showChoosers();
-
-            context.subscriptions.push(tasksWatcher);
-        });
+    let tasksFile: string;
 
     if (vsc.workspace.rootPath) {
+        tasksFile = path.join(vsc.workspace.rootPath, '.vscode', 'tasks.json')
+
         fs.stat(tasksFile, (err) => {
             if (err) {
                 tasksGenerator = vsc.window.createStatusBarItem(vsc.StatusBarAlignment.Right);
@@ -312,6 +306,24 @@ function start(context: vsc.ExtensionContext) {
             }
         });
     }
+
+    registerCommands(context.subscriptions, dub)
+        .then(dcdClientTool.setup.bind(dcdClientTool))
+        .then(dcdServerTool.setup.bind(dcdServerTool))
+        .then(dfmtTool.setup.bind(dfmtTool))
+        .then(dscannerTool.setup.bind(dscannerTool))
+        .then(() => {
+            if (vsc.workspace.rootPath) {
+                let tasksWatcher = vsc.workspace.createFileSystemWatcher(tasksFile);
+
+                tasksWatcher.onDidCreate(tasks.showChoosers.bind(tasks), null, context.subscriptions);
+                tasksWatcher.onDidChange(tasks.updateChoosers.bind(tasks), null, context.subscriptions);
+                tasksWatcher.onDidDelete(tasks.hideChoosers.bind(tasks), null, context.subscriptions);
+                tasks.showChoosers();
+
+                context.subscriptions.push(tasksWatcher);
+            }
+        });
 };
 
 function registerCommands(subscriptions: vsc.Disposable[], dub: Dub) {

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -1,5 +1,3 @@
 'use strict';
 
-import * as vsc from 'vscode';
-
 export const D_MODE = { language: 'd', scheme: 'file' };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -82,11 +82,9 @@ export default class Provider extends ev.EventEmitter implements
                     });
                 });
 
-                Promise.all(promises).then((symbolInformationLists) => {
-                    resolve(symbolInformationLists.reduce((previous, current) => {
-                        return current ? (previous || []).concat(current) : previous;
-                    }));
-                });
+                Promise.all(promises).then((symbolInformationLists) =>
+                    resolve(symbolInformationLists.reduce((previous, current) =>
+                        current ? (previous || []).concat(current) : previous)));
             });
         });
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -104,13 +104,15 @@ export default class Provider extends ev.EventEmitter implements
                 let fix = dscannerUtil.fixes.get(<string>d.code);
                 return Object.assign({ arguments: [d, ...fix.getArgs(document, range)] }, fix.command);
             });
-        let disablers = filteredDiagnostics
-            .filter((d) => dscannerUtil.fixes.get(<string>d.code).checkName)
-            .map((d) => ({
-                title: 'Disable Check: ' + d.code,
-                command: 'dlang.actions.config',
-                arguments: [d.code]
-            }));
+        let disablers = vsc.workspace.rootPath
+            ? filteredDiagnostics
+                .filter((d) => dscannerUtil.fixes.get(<string>d.code).checkName)
+                .map((d) => ({
+                    title: 'Disable Check: ' + d.code,
+                    command: 'dlang.actions.config',
+                    arguments: [d.code]
+                }))
+            : [];
 
         return actions.concat(disablers);
     }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -15,10 +15,8 @@ export default class Tasks implements vsc.Disposable {
     public static get compilers() {
         let compilers = [
             'dmd',
-            'ldc',
             'ldc2',
             'gdc',
-            'ldmd',
             'ldmd2',
             'gdmd'
         ];

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -205,36 +205,12 @@ const defaultTasks = {
         {
             'taskName': 'build',
             'isBuildCommand': true,
-            'problemMatcher': {
-                'fileLocation': [
-                    'relative',
-                    '${workspaceRoot}'
-                ],
-                'pattern': {
-                    'regexp': '^(.+\\.di?)[\\D](\\d+)(,|:)?(\\d+)?\\S+\\s+([Ee]rror|[Ww]arning):\\s+(.+)$',
-                    'file': 1,
-                    'line': 2,
-                    'column': 4,
-                    'severity': 5,
-                    'message': 6
-                }
-            },
+            'problemMatcher': '$dub-build'
         },
         {
             'taskName': 'test',
             'isTestCommand': true,
-            'problemMatcher': {
-                'fileLocation': [
-                    'relative',
-                    '${workspaceRoot}'
-                ],
-                'pattern': {
-                    'regexp': '^.+@(.+\\.di?)\\((\\d+)\\S+\\s+(.+)$',
-                    'file': 1,
-                    'line': 2,
-                    'message': 3
-                }
-            }
+            'problemMatcher': '$dub-test'
         },
         {
             'taskName': 'run'

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -6,6 +6,20 @@ import * as path from 'path';
 import * as vsc from 'vscode';
 
 export default class Tasks implements vsc.Disposable {
+    private static _builds = [
+        'debug',
+        'plain',
+        'release',
+        'release-debug',
+        'release-nobounds',
+        'unittest',
+        'profile',
+        'profile-gc',
+        'docs',
+        'ddox',
+        'cov',
+        'unittest-cov'
+    ];
     private _tasksFile: string;
     private _choosers: {
         compiler: vsc.StatusBarItem,
@@ -13,44 +27,22 @@ export default class Tasks implements vsc.Disposable {
     };
 
     public static get compilers() {
-        let compilers = [
-            'dmd',
-            'ldc2',
-            'gdc',
-            'ldmd2',
-            'gdmd'
-        ];
-
         let installedCompilers = new Set<string>();
         let isWin = process.platform === 'win32';
 
-        compilers.forEach((compiler) => {
+        ['dmd', 'ldc2', 'gdc', 'ldmd2', 'gdmd'].forEach((compiler) =>
             process.env.PATH.split(isWin ? ';' : ':').forEach((dir) => {
                 try {
                     fs.accessSync(path.join(dir, compiler + (isWin ? '.exe' : '')), fs.constants.F_OK);
                     installedCompilers.add(compiler);
                 } catch (e) { }
-            });
-        });
+            }));
 
         return Array.from(installedCompilers);
     }
 
     public static get builds() {
-        return [
-            'debug',
-            'plain',
-            'release',
-            'release-debug',
-            'release-nobounds',
-            'unittest',
-            'profile',
-            'profile-gc',
-            'docs',
-            'ddox',
-            'cov',
-            'unittest-cov'
-        ];
+        return Tasks._builds;
     }
 
     public constructor() {
@@ -96,11 +88,9 @@ export default class Tasks implements vsc.Disposable {
     }
 
     public getFile() {
-        return new Promise((resolve) => {
-            fs.readFile(this._tasksFile, (err, data) => {
-                resolve(err ? null : JSON.parse(data.toString()));
-            });
-        });
+        return new Promise((resolve) =>
+            fs.readFile(this._tasksFile, (err, data) =>
+                resolve(err ? null : JSON.parse(data.toString()))));
     }
 
     public showChoosers() {
@@ -119,28 +109,26 @@ export default class Tasks implements vsc.Disposable {
         this._choosers.compiler.text = '$(tools) ' + Tasks.compilers[0];
         this._choosers.build.text = '$(gear) ' + Tasks.builds[0];
 
-        this.apply((args) => {
-            args.forEach((arg) => {
-                let map = {
-                    compiler: {
-                        chooser: this._choosers.compiler,
-                        icon: '$(tools)'
-                    },
-                    build: {
-                        chooser: this._choosers.build,
-                        icon: '$(gear)'
-                    }
-                };
-
-                for (let regexp in map) {
-                    let match = arg.match(new RegExp(`--${regexp}=(.*)`));
-
-                    if (match) {
-                        map[regexp].chooser.text = map[regexp].icon + ' ' + match[1];
-                    }
+        this.apply((args) => args.forEach((arg) => {
+            let map = {
+                compiler: {
+                    chooser: this._choosers.compiler,
+                    icon: '$(tools)'
+                },
+                build: {
+                    chooser: this._choosers.build,
+                    icon: '$(gear)'
                 }
-            });
-        });
+            };
+
+            for (let regexp in map) {
+                let match = arg.match(new RegExp(`--${regexp}=(.*)`));
+
+                if (match) {
+                    map[regexp].chooser.text = map[regexp].icon + ' ' + match[1];
+                }
+            }
+        }));
     }
 
     public hideChoosers() {
@@ -175,17 +163,9 @@ export default class Tasks implements vsc.Disposable {
     }
 
     private changeArgument(argument: string, value: string, args: string[]) {
-        let compilerArg = args.find((arg) => {
-            return !!arg.match(new RegExp(`--${argument}=.*`));
-        });
-
-        let newArg = `--${argument}=` + value;
-
-        args.push(newArg);
-
-        return args.filter((arg) => {
-            return arg !== compilerArg;
-        });
+        let compilerArg = args.find((arg) => !!arg.match(new RegExp(`--${argument}=.*`)));
+        args.push(`--${argument}=` + value);
+        return args.filter((arg) => arg !== compilerArg);
     }
 };
 

--- a/syntaxes/d.tmLanguage
+++ b/syntaxes/d.tmLanguage
@@ -207,59 +207,61 @@
 		<dict>
 			<key>begin</key>
 			<string>(?x)(?&lt;=^|\}|;)\s*
-					((?:\b(public|private|protected|static|final|synchronized|abstract|export|shared)\b\s*)*) # modifier
-					(class|interface)\s+
-					(\w+)\s* # identifier
-					(?:\(\s*([^\)]+)\s*\)|)\s* # Template type
+					(?&lt;meta_modifier&gt;
+						(?:
+							(?:
+								(?:(?:\b(?:public|private|protected|static|final|synchronized|abstract|export|shared)\b)) |
+								(?:\b(?:extern)\b(?:\s*\(\s*(?:(?:(?:C\+\+)(?:\s*,\s*[A-Za-z_][A-Za-z0-9._]*)?)|\b(?:C|D|Windows|Pascal|System|Objective-C)\b)\s*\))?)
+							)\s*
+						)*
+					)
+					(?&lt;structure&gt;class|interface)\s+
+					(?&lt;identifier&gt;\w+)\s* # identifier
+					(?:\(\s*(?&lt;template_params&gt;[^\)]+)\s*\)|)\s* # Template type
 					(?:
-					  \s*(:)\s*
-					  (\w+)
-					  (?:\s*,\s*(\w+))?
-					  (?:\s*,\s*(\w+))?
-					  (?:\s*,\s*(\w+))?
-					  (?:\s*,\s*(\w+))?
-					  (?:\s*,\s*(\w+))?
-					  (?:\s*,\s*(\w+))?
+					  \s*(?&lt;inheritance_separator&gt;:)\s*
+					  (?&lt;inherited&gt;\w+)
+					  (?:\s*,\s*(?&lt;inherited&gt;\w+))?
+					  (?:\s*,\s*(?&lt;inherited&gt;\w+))?
+					  (?:\s*,\s*(?&lt;inherited&gt;\w+))?
+					  (?:\s*,\s*(?&lt;inherited&gt;\w+))?
+					  (?:\s*,\s*(?&lt;inherited&gt;\w+))?
+					  (?:\s*,\s*(?&lt;inherited&gt;\w+))?
 					)? # super class
 					</string>
 			<key>beginCaptures</key>
 			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.modifier.d</string>
-				</dict>
-				<key>10</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.d</string>
-				</dict>
-				<key>11</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.d</string>
-				</dict>
-				<key>12</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.d</string>
-				</dict>
-				<key>13</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.d</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.structure.d</string>
-				</dict>
-				<key>4</key>
+				<key>identifier</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.type.class.d</string>
 				</dict>
-				<key>5</key>
+				<key>inheritance_separator</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.inheritance.d</string>
+				</dict>
+				<key>inherited</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.inherited-class.d</string>
+				</dict>
+				<key>meta_modifier</key>
+				<dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#meta-modifier</string>
+						</dict>
+					</array>
+				</dict>
+				<key>structure</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.structure.d</string>
+				</dict>
+				<key>template_params</key>
 				<dict>
 					<key>patterns</key>
 					<array>
@@ -268,26 +270,6 @@
 							<string>$base</string>
 						</dict>
 					</array>
-				</dict>
-				<key>6</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.inheritance.d</string>
-				</dict>
-				<key>7</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.d</string>
-				</dict>
-				<key>8</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.d</string>
-				</dict>
-				<key>9</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.d</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -328,29 +310,41 @@
 		<dict>
 			<key>begin</key>
 			<string>(?x)(?&lt;=^|\}|;)\s*
-					((?:\b(public|private|protected|static|final|synchronized|abstract|export|shared)\b\s*)*) # modifier
-					(struct)\s+
-					(\w+)\s* # identifier
-					(?:\(\s*([^\)]+)\s*\)|)\s* # Template type
+					(?&lt;meta_modifier&gt;
+						(?:
+							(?:
+								(?:(?:\b(?:public|private|protected|static|final|synchronized|abstract|export|shared)\b)) |
+								(?:\b(?:extern)\b(?:\s*\(\s*(?:(?:(?:C\+\+)(?:\s*,\s*[A-Za-z_][A-Za-z0-9._]*)?)|\b(?:C|D|Windows|Pascal|System|Objective-C)\b)\s*\))?)
+							)\s*
+						)*
+					)
+					(?&lt;structure&gt;struct)\s+
+					(?&lt;identifier&gt;\w+)\s*
+					(?:\(\s*(?&lt;template_params&gt;[^\)]+)\s*\)|)\s*
 					</string>
 			<key>beginCaptures</key>
 			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.modifier.d</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.structure.d</string>
-				</dict>
-				<key>4</key>
+				<key>identifier</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.type.struct.d</string>
 				</dict>
-				<key>5</key>
+				<key>meta_modifier</key>
+				<dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#meta-modifier</string>
+						</dict>
+					</array>
+				</dict>
+				<key>structure</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.structure.d</string>
+				</dict>
+				<key>template_params</key>
 				<dict>
 					<key>patterns</key>
 					<array>
@@ -591,22 +585,17 @@
 			<dict>
 				<key>1</key>
 				<dict>
-					<key>name</key>
-					<string>keyword.other.external.d</string>
-				</dict>
-				<key>5</key>
-				<dict>
-					<key>name</key>
-					<string>constant.language.external.d</string>
-				</dict>
-				<key>7</key>
-				<dict>
-					<key>name</key>
-					<string>constant.language.external.d</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#meta-external</string>
+						</dict>
+					</array>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(extern)\b(\s*\(\s*(((C\+\+)(\s*,\s*[A-Za-z_][A-Za-z0-9._]*)?)|(C|D|Windows|Pascal|System))\s*\))?</string>
+			<string>(\b(?:extern)\b(?:\s*\(\s*(?:(?:(?:C\+\+)(?:\s*,\s*[A-Za-z_][A-Za-z0-9._]*)?)|\b(?:C|D|Windows|Pascal|System|Objective-C)\b)\s*\))?)</string>
 			<key>name</key>
 			<string>meta.external.d</string>
 		</dict>
@@ -1177,6 +1166,56 @@
 			<string>(?i:%(\([a-z_]+\))?#?0?\-?[ ]?\+?([0-9]*|\*)(\.([0-9]*|\*))?[hL]?[a-z%])</string>
 			<key>name</key>
 			<string>constant.other.placeholder.d</string>
+		</dict>
+		<key>meta-external</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>identifier</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.external.d</string>
+				</dict>
+				<key>keyword</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.external.d</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>\b(?&lt;keyword&gt;extern)\b(\s*\(\s*(?:(?:(?&lt;identifier&gt;C\+\+)(?:\s*,\s*[A-Za-z_][A-Za-z0-9._]*)?)|(?&lt;identifier&gt;C|D|Windows|Pascal|System|Objective-C))\s*\))?</string>
+			<key>name</key>
+			<string>meta.external.d</string>
+		</dict>
+		<key>meta-modifier</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>meta_external</key>
+				<dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#meta-external</string>
+						</dict>
+					</array>
+				</dict>
+				<key>modifier</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.d</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?x)
+				(?:
+					(?&lt;modifier&gt;\b(?:public|private|protected|static|final|synchronized|abstract|export|shared)\b) |
+					(?&lt;meta_external&gt;\b(?:extern)\b(?:\s*\(\s*(?:(?:(?:C\+\+)(?:\s*,\s*[A-Za-z_][A-Za-z0-9._]*)?)|\b(?:C|D|Windows|Pascal|System|Objective-C)\b)\s*\))?)
+				)\s*
+			</string>
+			<key>name</key>
+			<string>meta.modifier.d</string>
 		</dict>
 		<key>regular_expressions</key>
 		<dict>


### PR DESCRIPTION
These commits contain very simple updates.
- Tools fetched by dub are now the latest version instead of the latest "stable" version, which should automatically bring a bunch of bugfixes, and also fixes building some tools with the latest DMD versions (this should help fix #21)
- With VSCode 1.11, new completions were added (for structs and enum members notably)
- Problem matchers for `tasks.json` files are now declared in `package.json` (again thanks to VSCode 1.11)

The rest is basically cleaning up and simplifying things.
@mattiascibien this PR still touches about every typescript file in the project, so I'll try to get on some unit tests creation now before everything explodes for no apparent reason

EDIT:
While working on tests, I realized how bad the extension was at working with single files with no folder open, hence this [added commit](https://github.com/dlang-vscode/dlang-vscode/pull/39/commits/90b66a43fba938f51d259f2cdb51d00013e22d00)