### PR TITLE
Solve that dependencie changed its ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -547,6 +547,6 @@
         "xml2js": "^0.4.19"
     },
     "extensionDependencies": [
-        "LaurentTreguier.sdlang"
+        "laurenttreguier.vscode-dls"
     ]
 }


### PR DESCRIPTION
The dependencie `LaurentTreguier.sdlang` changed its ID to `laurenttreguier.vscode-dls`, crashing the extension on every startup of vscode.